### PR TITLE
feat(templates): adds simple conference template from Console templates

### DIFF
--- a/conference/README.md
+++ b/conference/README.md
@@ -1,0 +1,11 @@
+# Conference
+
+This Function in `conference.js` will return the TwiML required to put a call into a conference. The conference is called "Snowy Owl" by default.
+
+### Environment variables
+
+This Function doesn't need any environment variables.
+
+### Parameters
+
+This Function expects the incoming request to be a voice webhook. It doesn't expect any incoming parameters.

--- a/conference/functions/conference.js
+++ b/conference/functions/conference.js
@@ -1,0 +1,14 @@
+/**
+ * Conference Template
+ *
+ * This Function creates a conference line that people can call-in to. Learn more about using <Conference> here:
+ * https://www.twilio.com/docs/api/twiml/conference
+ */
+
+exports.handler = function(context, event, callback) {
+  const twiml = new Twilio.twiml.VoiceResponse();
+  // Change the conference name to anything you like.
+  const conferenceName = 'Snowy Owl';
+  twiml.dial().conference(conferenceName);
+  callback(null, twiml);
+};

--- a/conference/package.json
+++ b/conference/package.json
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}

--- a/conference/tests/conference.test.js
+++ b/conference/tests/conference.test.js
@@ -1,0 +1,34 @@
+const conference = require('../functions/conference').handler;
+const helpers = require('../../test/test-helper');
+
+describe('simple conference', () => {
+  const context = {};
+  const event = {};
+  beforeAll(() => {
+    helpers.setup(context);
+  });
+
+  afterAll(() => {
+    helpers.teardown();
+  });
+
+  it('returns a VoiceResponse', done => {
+    const callback = (err, result) => {
+      expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+      done();
+    };
+
+    conference(context, event, callback);
+  });
+
+  it('connects a call to a conference called Snowy Owl', done => {
+    const callback = (err, result) => {
+      expect(result.toString()).toMatch(
+        '<Dial><Conference>Snowy Owl</Conference></Dial>'
+      );
+      done();
+    };
+
+    conference(context, event, callback);
+  });
+});

--- a/templates.json
+++ b/templates.json
@@ -46,6 +46,11 @@
       "description": "Uses SendGrid to forward incoming messages via email"
     },
     {
+      "id": "conference",
+      "name": "Simple Conference",
+      "description": "Drops all incoming calls into a conference room"
+    },
+    {
       "id": "chat-token",
       "name": "Chat Token Function",
       "description": "Generates a Chat Access Token for client-side applications"


### PR DESCRIPTION
This is not as comprehensive as the [conference twimlet](https://github.com/twilio-labs/function-templates/issues/19) but this does replicate the existing [conference template from the Functions console](https://www.twilio.com/console/functions/manage).

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
