### PR TITLE
Fix typo which popped up in the CLI function template overview

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -33,7 +33,7 @@
     {
       "id": "forward-message",
       "name": "Forward Message",
-      "description": "Forwards an incoming messages to another number"
+      "description": "Forwards incoming messages to another number"
     },
     {
       "id": "forward-message-multiple",


### PR DESCRIPTION
Headline says it all. :) 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
