### PR TITLE
fix README link to Code of Conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Pull requests and new Functions are accepted. To make a contribution, follow the
 4. Push to the branch (git push origin my-new-feature)
 5. Create a new Pull Request
 
-Please note that this project is released with a [Contributor Code of Conduct](#CODE_OF_CONDUCT). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
 ### Install
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Pull requests and new Functions are accepted. To make a contribution, follow the
 4. Push to the branch (git push origin my-new-feature)
 5. Create a new Pull Request
 
-Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](#CODE_OF_CONDUCT). By participating in this project you agree to abide by its terms.
 
 ### Install
 


### PR DESCRIPTION
<!-- Describe your Pull Request -->
the link to the Code of Conduct was missing the file extension, resulting in a 404 error when following the link. I added .md et voila. 


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
