### PR TITLE
Add Hold Music Funlet

### DIFF
--- a/hold-music/.env
+++ b/hold-music/.env
@@ -1,0 +1,4 @@
+# Amazon S3 Bucket holding your hold music.
+BUCKET=
+# Message to say or URL to play between each song.
+MESSAGE=

--- a/hold-music/README.md
+++ b/hold-music/README.md
@@ -24,3 +24,4 @@ This Function expects the following environment variables set:
 This Function requires no URL or POST parameters to run successfully.
 
 [s3-homepage]: https://s3.amazonaws.com/
+[twimlet]: https://www.twilio.com/labs/twimlets/holdmusic

--- a/hold-music/README.md
+++ b/hold-music/README.md
@@ -1,0 +1,26 @@
+# Hold Music
+
+Plays the audio fields in an [Amazon S3 Bucket][s3-homepage] in a loop,
+optionally playing a URL or saying a message between each song.
+
+This Twilio Function is based on the [Twimlet of the same name][twimlet].
+
+[twimlet]: https://www.twilio.com/labs/twimlets/hold-music
+
+It can be used as a drop-in replacement for the Twimlet, by using the URL
+of the Twilio Function as a webhook with the same GET parameters.
+
+## Environment variables
+
+This Function expects the following environment variables set:
+
+| Variable  | Meaning                                                                               | Required |
+| :-------- | :------------------------------------------------------------------------------------ | :------- |
+| `BUCKET`  | The public [Amazon S3 bucket][s3-homepage] to read the music files from. | Yes      |
+| `MESSAGE` | A URL of a file to play, or text to say, between songs.                               | No       |
+
+## Parameters
+
+This Function requires no URL or POST parameters to run successfully.
+
+[s3-homepage]: https://s3.amazonaws.com/

--- a/hold-music/functions/hold-music.js
+++ b/hold-music/functions/hold-music.js
@@ -1,0 +1,95 @@
+const URL = require('url').URL;
+
+const fetch = require('node-fetch');
+const parser = require('fast-xml-parser');
+
+const FETCH_TIMEOUT = 5000;
+
+function shuffle(arr) {
+    arr = arr.slice();
+
+    let len = arr.length;
+
+    while (len) {
+        let random = Math.floor(Math.random() * len);
+        len -= 1;
+        let temp = arr[len];
+        arr[len] = arr[random];
+        arr[random] = temp;
+    }
+
+    return arr;
+}
+
+function getBucketURL(bucket, path) {
+  const base = 'http://' + bucket + '.s3.amazonaws.com';
+  path = path || '/';
+
+  return new URL(path, base).toString();
+}
+
+function getBucketMusic(bucket) {
+  const bucketURL = getBucketURL(bucket);
+
+  return fetch(bucketURL, { timeout: FETCH_TIMEOUT })
+      .then(res => res.text())
+      .then(text => parser.parse(text))
+      .then(result => {
+          if (!result || !result['ListBucketResult'] || !result['ListBucketResult']['Contents']) {
+              return [];
+          }
+
+          let contents = result['ListBucketResult']['Contents'];
+
+          return Array.isArray(contents) ? contents : [contents];
+      })
+      .then(contents => contents.map(c => getBucketURL(bucket, c['Key'])).filter(c => c.match(/\.(mp3|wav|ul)$/i)))
+      .catch(() => []);
+}
+
+function isURL(input) {
+  try {
+    new URL(input);
+  } catch (e) {
+    return false;
+  }
+  return true;
+}
+
+exports.handler = function(context, event, callback) {
+  const twiml = new Twilio.twiml.VoiceResponse();
+
+  const bucketName = context.BUCKET || null;
+  const message = context.MESSAGE || null;
+
+  if (!bucketName) {
+    twiml.say('An S 3 bucket is required.');
+    callback(null, twiml);
+
+    return
+  }
+
+  return getBucketMusic(bucketName)
+      .then(playlist => {
+        if (!playlist || playlist.length === 0) {
+          twiml.say('Failed to fetch the hold music.');
+          return twiml;
+        }
+
+        playlist = shuffle(playlist);
+
+        for (let songURL of playlist) {
+            twiml.play(songURL);
+
+            if (isURL(message)) {
+                twiml.play(message);
+            } else if (message) {
+                twiml.say(message);
+            }
+        }
+
+        twiml.redirect();
+        return twiml;
+      })
+      .then(twiml => callback(null, twiml));
+};

--- a/hold-music/functions/hold-music.js
+++ b/hold-music/functions/hold-music.js
@@ -95,9 +95,25 @@ async function getHoldMusicTwiml(bucketName, message) {
   return twiml;
 }
 
+function getParameter(key, context, event) {
+  if (context && context[key.toUpperCase()]) {
+    return context[key.toUpperCase()];
+  }
+
+  if (event) {
+    let eventKey = Object.keys(event).find(k => k.toLowerCase() === key.toLowerCase());
+
+    if (eventKey) {
+      return event[eventKey];
+    }
+  }
+
+  return null;
+}
+
 exports.handler = async function(context, event, callback) {
-  const bucketName = context.BUCKET || null;
-  const message = context.MESSAGE || null;
+  const bucketName = getParameter('bucket', context, event);
+  const message = getParameter('message', context, event);
 
   try {
     let twiml = await getHoldMusicTwiml(bucketName, message);

--- a/hold-music/functions/hold-music.js
+++ b/hold-music/functions/hold-music.js
@@ -42,24 +42,33 @@ function isURL(input) {
 async function getBucketMusic(bucket) {
   const bucketURL = getBucketURL(bucket);
 
-  try {
-    let res = await fetch(bucketURL, {timeout: FETCH_TIMEOUT});
+  let res = await fetch(bucketURL, {timeout: FETCH_TIMEOUT});
 
-    let result = parser.parse(await res.text());
+  // If S3 responds with a response outside of 200 level / 300 level then
+  // let's throw an exception because something's real wrong here.
+  if (!res.ok) {
+    throw new Error('Invalid Response from S3');
+  }
 
-    if (!result || !result['ListBucketResult'] || !result['ListBucketResult']['Contents']) {
-      return [];
-    }
+  let doc = parser.parse(await res.text());
 
-    let contents = result['ListBucketResult']['Contents'];
-
-    contents = Array.isArray(contents) ? contents : [contents];
-    return contents
-        .map(c => getBucketURL(bucket, c['Key']))
-        .filter(c => c.match(VALID_MUSIC_REGEX));
-  } catch (err) {
+  // In various cases the response message will be `ok` but the response won't
+  // have any contents.  This is no good and we should assume no records.
+  if (!doc || !doc['ListBucketResult'] || !doc['ListBucketResult']['Contents']) {
     return [];
   }
+
+  let contents = doc['ListBucketResult']['Contents'];
+
+  // `Contents` are an XML element, and the response can be One or Many.
+  // As such, the XML parser doesn't know that we want an array, so
+  // let's coerce our results if they aren't an array.
+  contents = Array.isArray(contents) ? contents : [contents];
+
+  return contents
+      .map(c => getBucketURL(bucket, c['Key']))
+      .filter(c => isURL(c) && c.match(VALID_MUSIC_REGEX));
+
 }
 
 async function getHoldMusicTwiml(bucketName, message) {
@@ -70,11 +79,20 @@ async function getHoldMusicTwiml(bucketName, message) {
     return twiml;
   }
 
-  let playlist = await getBucketMusic(bucketName);
+  let playlist;
+
+  try {
+    playlist = await getBucketMusic(bucketName);
+  } catch (err) {
+    // In case of an error, to match the Twimlet we're going to respond as if
+    // there was no hold music found.
+    playlist = [];
+  }
 
   if (!playlist || playlist.length === 0) {
+    // There are various reasons why we wouldn't be able to get the bucket music.
+    // In these cases we need to inform the caller.
     twiml.say('Failed to fetch the hold music.');
-
     return twiml;
   }
 
@@ -84,6 +102,7 @@ async function getHoldMusicTwiml(bucketName, message) {
     twiml.play(songURL);
 
     if (isURL(message)) {
+      // If the message is a URL we're support to play it as music
       twiml.play(message);
     } else if (message) {
       twiml.say(message);
@@ -101,6 +120,8 @@ function getParameter(key, context, event) {
   }
 
   if (event) {
+    // It's unclear the casing that can be brought into the `event` object - as such,
+    // let's search throw the event keys until we find something that matches..
     let eventKey = Object.keys(event).find(k => k.toLowerCase() === key.toLowerCase());
 
     if (eventKey) {

--- a/hold-music/package.json
+++ b/hold-music/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "fast-xml-parser": "^3.13.0",
+    "node-fetch": "^2.6.0"
+  }
+}

--- a/hold-music/tests/hold-music.test.js
+++ b/hold-music/tests/hold-music.test.js
@@ -1,0 +1,276 @@
+const holdMusicHandler = require('../functions/hold-music').handler;
+const helpers = require('../../test/test-helper');
+const fetch = require('node-fetch');
+
+jest.mock('node-fetch', () => jest.fn());
+
+const FetchResponse = jest.requireActual('node-fetch').Response;
+const FetchError = jest.requireActual('node-fetch').FetchError;
+
+const mockMath = Object.create(global.Math);
+mockMath.random = jest.fn().mockReturnValue(0.5);
+global.Math = mockMath;
+
+function callbackHelper(done, callback) {
+  let callCount = 0;
+
+  return function(err, result) {
+    callCount += 1;
+
+    try {
+      expect(callCount).toEqual(1);
+
+      callback(err, result);
+      done();
+    } catch(e) {
+      done(e);
+    }
+  }
+}
+
+beforeAll(() => {
+  helpers.setup({});
+});
+
+afterAll(() => {
+  helpers.teardown();
+});
+
+beforeEach(() => fetch.mockReset());
+
+
+// HOLD-MUSIC-1
+describe('a missing S3 Bucket parameter', () => {
+  test('says that the bucket is required when missing', done => {
+    const callback = (err, result) => {
+      expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+      expect(result.toString()).toMatch(
+        '<Response><Say>An S 3 bucket is required.</Say></Response>'
+      );
+      done();
+    };
+
+    holdMusicHandler({}, {}, callback);
+  });
+
+  test('says that the bucket is required when null', done => {
+    const callback = (err, result) => {
+      expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+      expect(result.toString()).toMatch(
+          '<Response><Say>An S 3 bucket is required.</Say></Response>'
+      );
+      done();
+    };
+
+    holdMusicHandler({BUCKET: null}, {}, callback);
+  });
+
+  test('says that the bucket is required when empty', done => {
+    const callback = (err, result) => {
+      expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+      expect(result.toString()).toMatch(
+          '<Response><Say>An S 3 bucket is required.</Say></Response>'
+      );
+      done();
+    };
+
+    holdMusicHandler({BUCKET: ''}, {}, callback);
+  });
+});
+
+
+// Test Case HOLD-MUSIC-2
+describe('a failed S3 bucket download', () => {
+  test('handles bucket timeout', done => {
+    fetch.mockReturnValue(
+        Promise.reject(new FetchError('network timeout at: http://mock.url/', 'request-timeout'))
+    );
+
+    const callback = callbackHelper(done, (err, result) => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith('http://example.s3.amazonaws.com/', {timeout: 5000});
+
+      expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+      expect(result.toString()).toMatch(
+          '<Response><Say>Failed to fetch the hold music.</Say></Response>'
+      );
+    });
+
+    holdMusicHandler({BUCKET: 'example'}, {}, callback);
+  });
+
+  test('handles bucket not found', done => {
+    fetch.mockReturnValue(
+        Promise.resolve(new FetchResponse(
+            '<Error>' +
+            '<Code>NoSuchBucket</Code>' +
+            '<Message>The specified bucket does not exist</Message>' +
+            '<BucketName>example</BucketName>' +
+            '</Error>',
+            {status: 404}
+        ))
+    );
+
+    const callback = callbackHelper(done, (err, result) => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith('http://example.s3.amazonaws.com/', {timeout: 5000});
+
+      expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+      expect(result.toString()).toMatch(
+          '<Response><Say>Failed to fetch the hold music.</Say></Response>'
+      );
+    });
+
+    holdMusicHandler({BUCKET: 'example'}, {}, callback);
+  });
+});
+
+
+// Test Case HOLD-MUSIC-3
+describe('download successful but no available songs', () => {
+  test('handles bucket empty', done => {
+    fetch.mockReturnValue(Promise.resolve(new FetchResponse('<ListBucketResult><Prefix/></ListBucketResult>')));
+
+    const callback = callbackHelper(done, (err, result) => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith('http://example.s3.amazonaws.com/', {timeout: 5000});
+
+      expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+      expect(result.toString()).toMatch(
+          '<Response><Say>Failed to fetch the hold music.</Say></Response>'
+      );
+    });
+
+    holdMusicHandler({BUCKET: 'example'}, {}, callback);
+  });
+
+  test('handles bucket without music', done => {
+    fetch.mockReturnValue(Promise.resolve(new FetchResponse('<ListBucketResult><Prefix/><Contents><Key>license.txt</Key></Contents></ListBucketResult>')));
+
+    const callback = callbackHelper(done, (err, result) => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith('http://example.s3.amazonaws.com/', {timeout: 5000});
+
+      expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+      expect(result.toString()).toMatch(
+          '<Response><Say>Failed to fetch the hold music.</Say></Response>'
+      );
+    });
+
+    holdMusicHandler({BUCKET: 'example'}, {}, callback);
+  });
+});
+
+
+// Test Case HOLD-MUSIC-4
+describe('when fetching songs without a message', () => {
+  test('then fetches items from the bucket and shuffles', done => {
+    fetch.mockReturnValue(Promise.resolve(
+        new FetchResponse(
+            '<ListBucketResult><Prefix/>' +
+            '<Contents><Key>foo.mp3</Key></Contents>' +
+            '<Contents><Key>bar.mp3</Key></Contents>' +
+            '<Contents><Key>baz.mp3</Key></Contents>' +
+            '</ListBucketResult>'
+        )
+    ));
+
+    const callback = callbackHelper(done, (err, result) => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith('http://example.s3.amazonaws.com/', {timeout: 5000});
+
+      expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+      expect(result.toString()).toMatch(
+          '<Response>' +
+          '<Play>http://example.s3.amazonaws.com/foo.mp3</Play>' +
+          '<Play>http://example.s3.amazonaws.com/baz.mp3</Play>' +
+          '<Play>http://example.s3.amazonaws.com/bar.mp3</Play>' +
+          '<Redirect/>' +
+          '</Response>'
+      );
+
+    });
+
+    holdMusicHandler({BUCKET: 'example'}, {}, callback);
+  });
+
+  test('then fetches items from the bucket and shuffles with a different seed', done => {
+    fetch.mockReturnValue(Promise.resolve(
+        new FetchResponse(
+            '<ListBucketResult><Prefix/>' +
+            '<Contents><Key>foo.mp3</Key></Contents>' +
+            '<Contents><Key>bar.mp3</Key></Contents>' +
+            '<Contents><Key>baz.mp3</Key></Contents>' +
+            '</ListBucketResult>'
+        )
+    ));
+
+    mockMath.random.mockReturnValueOnce(0.1);
+
+    const callback = callbackHelper(done, (err, result) => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith('http://example.s3.amazonaws.com/', {timeout: 5000});
+
+      expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+      expect(result.toString()).toMatch(
+          '<Response>' +
+          '<Play>http://example.s3.amazonaws.com/baz.mp3</Play>' +
+          '<Play>http://example.s3.amazonaws.com/bar.mp3</Play>' +
+          '<Play>http://example.s3.amazonaws.com/foo.mp3</Play>' +
+          '<Redirect/>' +
+          '</Response>'
+      );
+
+    });
+
+    holdMusicHandler({BUCKET: 'example'}, {}, callback);
+  });
+});
+
+
+// Test Case HOLD-MUSIC-5
+describe('when fetching songs with a message', () => {
+  test('then includes the message as Say if not URL', done => {
+    fetch.mockReturnValue(Promise.resolve(
+        new FetchResponse(
+            '<ListBucketResult><Prefix/>' +
+            '<Contents><Key>foo.mp3</Key></Contents>' +
+            '</ListBucketResult>'
+        )
+    ));
+
+    const callback = callbackHelper(done, (err, result) => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith('http://example.s3.amazonaws.com/', {timeout: 5000});
+
+      expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+      expect(result.toString()).toMatch(
+          '<Response><Play>http://example.s3.amazonaws.com/foo.mp3</Play><Say>hello world</Say><Redirect/></Response>'
+      );
+    });
+
+    holdMusicHandler({BUCKET: 'example', MESSAGE: 'hello world'}, {}, callback);
+  });
+
+  test('then includes the includes message as Play if URL', done => {
+    fetch.mockReturnValue(Promise.resolve(
+        new FetchResponse(
+            '<ListBucketResult><Prefix/>' +
+            '<Contents><Key>foo.mp3</Key></Contents>' +
+            '</ListBucketResult>'
+        )
+    ));
+
+    const callback = callbackHelper(done, (err, result) => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith('http://example.s3.amazonaws.com/', {timeout: 5000});
+
+      expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+      expect(result.toString()).toMatch(
+          '<Response><Play>http://example.s3.amazonaws.com/foo.mp3</Play><Play>https://example.com/testing</Play><Redirect/></Response>'
+      );
+    });
+
+    holdMusicHandler({BUCKET: 'example', MESSAGE: 'https://example.com/testing'}, {}, callback);
+  });
+});

--- a/hold-music/tests/hold-music.test.js
+++ b/hold-music/tests/hold-music.test.js
@@ -274,3 +274,29 @@ describe('fetching songs with a message', () => {
     holdMusicHandler({BUCKET: 'example', MESSAGE: 'https://example.com/testing'}, {}, callback);
   });
 });
+
+
+describe('an uncaught exception occurs in the handler', () => {
+  afterEach(() => {
+    if (Twilio.twiml.VoiceResponse.mockRestore) {
+      Twilio.twiml.VoiceResponse.mockRestore();
+    }
+  });
+
+  it('passes the error to the callback', done => {
+    let expected = new Error('testing');
+
+    let mockVoiceResponse = jest.spyOn(Twilio.twiml, 'VoiceResponse');
+
+    mockVoiceResponse.mockImplementation(() => { throw expected; });
+
+    const callback = callbackHelper(done, (err, result) => {
+      expect(result).toBeNull();
+
+      expect(err).not.toBeNull();
+      expect(err).toEqual(expected);
+    });
+
+    holdMusicHandler({BUCKET: 'example'}, {}, callback);
+  });
+});

--- a/hold-music/tests/hold-music.test.js
+++ b/hold-music/tests/hold-music.test.js
@@ -41,7 +41,7 @@ beforeEach(() => fetch.mockReset());
 
 // HOLD-MUSIC-1
 describe('a missing S3 Bucket parameter', () => {
-  test('says that the bucket is required when missing', done => {
+  it('says that the bucket is required when missing', done => {
     const callback = (err, result) => {
       expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
       expect(result.toString()).toMatch(
@@ -53,7 +53,7 @@ describe('a missing S3 Bucket parameter', () => {
     holdMusicHandler({}, {}, callback);
   });
 
-  test('says that the bucket is required when null', done => {
+  it('says that the bucket is required when null', done => {
     const callback = (err, result) => {
       expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
       expect(result.toString()).toMatch(
@@ -65,7 +65,7 @@ describe('a missing S3 Bucket parameter', () => {
     holdMusicHandler({BUCKET: null}, {}, callback);
   });
 
-  test('says that the bucket is required when empty', done => {
+  it('says that the bucket is required when empty', done => {
     const callback = (err, result) => {
       expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
       expect(result.toString()).toMatch(
@@ -81,7 +81,7 @@ describe('a missing S3 Bucket parameter', () => {
 
 // Test Case HOLD-MUSIC-2
 describe('a failed S3 bucket download', () => {
-  test('handles bucket timeout', done => {
+  it('handles bucket timeout', done => {
     fetch.mockReturnValue(
         Promise.reject(new FetchError('network timeout at: http://mock.url/', 'request-timeout'))
     );
@@ -99,7 +99,7 @@ describe('a failed S3 bucket download', () => {
     holdMusicHandler({BUCKET: 'example'}, {}, callback);
   });
 
-  test('handles bucket not found', done => {
+  it('handles bucket not found', done => {
     fetch.mockReturnValue(
         Promise.resolve(new FetchResponse(
             '<Error>' +
@@ -128,7 +128,7 @@ describe('a failed S3 bucket download', () => {
 
 // Test Case HOLD-MUSIC-3
 describe('download successful but no available songs', () => {
-  test('handles bucket empty', done => {
+  it('handles bucket empty', done => {
     fetch.mockReturnValue(Promise.resolve(new FetchResponse('<ListBucketResult><Prefix/></ListBucketResult>')));
 
     const callback = callbackHelper(done, (err, result) => {
@@ -144,7 +144,7 @@ describe('download successful but no available songs', () => {
     holdMusicHandler({BUCKET: 'example'}, {}, callback);
   });
 
-  test('handles bucket without music', done => {
+  it('handles bucket without music', done => {
     fetch.mockReturnValue(Promise.resolve(new FetchResponse('<ListBucketResult><Prefix/><Contents><Key>license.txt</Key></Contents></ListBucketResult>')));
 
     const callback = callbackHelper(done, (err, result) => {
@@ -163,8 +163,8 @@ describe('download successful but no available songs', () => {
 
 
 // Test Case HOLD-MUSIC-4
-describe('when fetching songs without a message', () => {
-  test('then fetches items from the bucket and shuffles', done => {
+describe('fetching songs without a message', () => {
+  it('fetches items from the bucket and shuffles', done => {
     fetch.mockReturnValue(Promise.resolve(
         new FetchResponse(
             '<ListBucketResult><Prefix/>' +
@@ -194,7 +194,7 @@ describe('when fetching songs without a message', () => {
     holdMusicHandler({BUCKET: 'example'}, {}, callback);
   });
 
-  test('then fetches items from the bucket and shuffles with a different seed', done => {
+  it('fetches items from the bucket and shuffles with a different seed', done => {
     fetch.mockReturnValue(Promise.resolve(
         new FetchResponse(
             '<ListBucketResult><Prefix/>' +
@@ -229,8 +229,8 @@ describe('when fetching songs without a message', () => {
 
 
 // Test Case HOLD-MUSIC-5
-describe('when fetching songs with a message', () => {
-  test('then includes the message as Say if not URL', done => {
+describe('fetching songs with a message', () => {
+  it('includes the message as Say if not URL', done => {
     fetch.mockReturnValue(Promise.resolve(
         new FetchResponse(
             '<ListBucketResult><Prefix/>' +
@@ -252,7 +252,7 @@ describe('when fetching songs with a message', () => {
     holdMusicHandler({BUCKET: 'example', MESSAGE: 'hello world'}, {}, callback);
   });
 
-  test('then includes the includes message as Play if URL', done => {
+  it('includes the includes message as Play if URL', done => {
     fetch.mockReturnValue(Promise.resolve(
         new FetchResponse(
             '<ListBucketResult><Prefix/>' +

--- a/package-lock.json
+++ b/package-lock.json
@@ -2059,6 +2059,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-xml-parser": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.13.0.tgz",
+      "integrity": "sha512-XYXC39VjE9dH6jpp5Gm5gsuR8Z4bMz44qMpT1PmqR+iyOJMhC0LcsN81asYkHP4OkEX8TTR8d6V/caCmy8Q8jQ=="
+    },
     "fb-watchman": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
@@ -4415,6 +4420,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
       "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     ]
   },
   "dependencies": {
+    "fast-xml-parser": "^3.13.0",
     "got": "^6.7.1",
+    "node-fetch": "^2.6.0",
     "twilio": "^3.33.2"
   }
 }


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Adds a "Hold Music" funlet, similar to the [`hold-music` twimlet][twimlet].

Instead of accepting HTTP parameters for defining the bucket & message, this instead uses environment variables.

Closes #20

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

[twimlet]: https://www.twilio.com/labs/twimlets/holdmusic