### PR TITLE
Adds links to media in email when forwarding to SendGrid

### DIFF
--- a/forward-message-sendgrid/functions/forward-message-sendgrid.js
+++ b/forward-message-sendgrid/functions/forward-message-sendgrid.js
@@ -1,6 +1,14 @@
 const got = require('got');
 
 exports.handler = function(context, event, callback) {
+  let emailBody = event.Body || '';
+  const numMedia = parseInt(event.NumMedia, 10);
+  if (numMedia > 0) {
+    emailBody += "\n\n";
+    for (let i = 0; i < numMedia; i++) {
+      emailBody += event[`MediaUrl${i}`] + "\n";
+    }
+  }
   const requestBody = {
     personalizations: [{ to: [{ email: context.TO_EMAIL_ADDRESS }] }],
     from: { email: context.FROM_EMAIL_ADDRESS },
@@ -8,7 +16,7 @@ exports.handler = function(context, event, callback) {
     content: [
       {
         type: 'text/plain',
-        value: event.Body,
+        value: emailBody,
       },
     ],
   };


### PR DESCRIPTION
## Description

According to #92 when sending a message consisting of just media content the `forward-to-sendgrid` function errors. This PR will create an email body out of the message body and any media URLs that have been sent.

More ideal would be downloading and attaching the media. This is a quickish fix for now.

Does this work for you @jeremiahlee?

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

## Related issues

#92
