### PR TITLE
fix(video-token): add to .env to add stub for SID

### DIFF
--- a/video-token/.env
+++ b/video-token/.env
@@ -1,3 +1,5 @@
+# Your Account Sid
+ACCOUNT_SID=
 # API key for your Twilio Account
 API_KEY=
 # API secret for your API Key


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

This is a very minor fix to the .env file when running the `video-token` function. 

This addition adds a stub for SID to the .env file to allow the function to run via `twilio serverless:start`. 

Prior to this the stackTrace error is `Error: keySid is required`. 

<img width="1147" alt="Screen Shot 2020-04-29 at 2 38 28 PM" src="https://user-images.githubusercontent.com/918117/80650544-0aefc780-8a29-11ea-8ffd-eedfd0f7d14d.png">

## Checklist

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).


