### PR TITLE
fix(meta-template): update init instructions

### DIFF
--- a/_helpers/meta-template/README.md
+++ b/_helpers/meta-template/README.md
@@ -40,7 +40,7 @@ twilio plugins:install @twilio-labs/plugin-serverless
 3. Initiate a new project
 
 ```
-twilio serverless:init example --template={{name}} && cd verify-sample
+twilio serverless:init example --template={{name}} && cd example
 ```
 
 4. Start the server with the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart):


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

When I copied the verify template to become the meta template I missed updating the folder name after calling `serverless:init`

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
