### PR TITLE
fix(sip-quickstart): limit to only 1 concurrent API request

### DIFF
--- a/sip-quickstart/assets/admin/actions.private.js
+++ b/sip-quickstart/assets/admin/actions.private.js
@@ -137,12 +137,12 @@ class Actions {
   }
 
   async addNewCredentials({ credentialListSid, usernames }) {
-    usernames.forEach(async (username) => {
+    for (let username of usernames) {
       await this.addNewCredential({
         credentialListSid,
         username,
       });
-    });
+    }
   }
 
   async updateSipDomainVoiceUrl({ sipDomainSid, voiceUrl }) {

--- a/sip-quickstart/assets/admin/actions.private.js
+++ b/sip-quickstart/assets/admin/actions.private.js
@@ -91,17 +91,16 @@ class Actions {
     const credentialList = await this.client.sip.credentialLists.create({
       friendlyName,
     });
-    const authCallsMapping = this.client.sip
+    await this.client.sip
       .domains(sipDomainSid)
       .auth.calls.credentialListMappings.create({
         credentialListSid: credentialList.sid,
       });
-    const domainRegistrationMapping = this.client.sip
+    await this.client.sip
       .domains(sipDomainSid)
       .auth.registrations.credentialListMappings.create({
         credentialListSid: credentialList.sid,
       });
-    await Promise.all([authCallsMapping, domainRegistrationMapping]);
     await this.client.sip.domains(sipDomainSid).update({
       sipRegistration: true,
     });
@@ -138,13 +137,12 @@ class Actions {
   }
 
   async addNewCredentials({ credentialListSid, usernames }) {
-    const promises = usernames.map((username) =>
-      this.addNewCredential({
+    usernames.forEach(async (username) => {
+      await this.addNewCredential({
         credentialListSid,
         username,
-      })
-    );
-    await Promise.all(promises);
+      });
+    });
   }
 
   async updateSipDomainVoiceUrl({ sipDomainSid, voiceUrl }) {


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

New users are temporarily limited to 1 concurrent API request. Previously this code made use of asynchronous activity for speed.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
