### PR TITLE
feat(meta): add index.html to template base

### DIFF
--- a/_helpers/add-template.js
+++ b/_helpers/add-template.js
@@ -20,7 +20,7 @@ async function promptQuestions() {
       name: 'name',
       type: 'input',
       message: `What's the name of your template? This will be used as your template ID`,
-      validate: text =>
+      validate: (text) =>
         validTemplateName.test(text) ||
         'Your name can only contain lowercase characters, numbers and "-"',
     },
@@ -28,7 +28,7 @@ async function promptQuestions() {
       name: 'title',
       type: 'input',
       message: 'Enter a plain text title for the template',
-      validate: text =>
+      validate: (text) =>
         (text && text.length > 0 && text.length < 51) ||
         'Please specify a title no longer than 50 characters.',
     },
@@ -36,14 +36,8 @@ async function promptQuestions() {
       name: 'description',
       type: 'input',
       message: 'Describe what your template does',
-      validate: text =>
+      validate: (text) =>
         (text && text.length > 0) || 'Please specify a short description',
-    },
-    {
-      name: 'hasAssets',
-      type: 'confirm',
-      message: 'Do you want to have assets in this template?',
-      default: false,
     },
   ]);
 }
@@ -75,24 +69,6 @@ async function addToTemplatesJson(name, title, description) {
   await writeFile(templatesJsonPath, resultContent, 'utf8');
 }
 
-async function createSampleAsset(title, targetPath) {
-  const assetsFolderPath = path.resolve(targetPath, 'assets');
-  await mkdir(assetsFolderPath);
-  const content = `<!DOCTYPE html>
-<html>
-  <head>
-    <title>${title}</title>
-  </head>
-  <body>
-    <h1>${title}</h1>
-    <p>Feel free to modify this file or add any additional static files to the assets folder</p>
-  </body>
-</html>
-`;
-  const assetFilePath = path.join(assetsFolderPath, 'index.html');
-  await writeFile(assetFilePath, content, 'utf8');
-}
-
 async function run() {
   const { name, description, title, hasAssets } = await promptQuestions();
 
@@ -115,11 +91,6 @@ async function run() {
       title: 'Adding template to templates.json',
       task: () => addToTemplatesJson(name, title, description),
     },
-    {
-      title: 'Creating sample assets',
-      task: () => createSampleAsset(title, targetPath),
-      skip: () => !hasAssets,
-    },
   ]);
 
   await tasks.run();
@@ -137,7 +108,7 @@ ${success} Template created
   console.warn(successMessage);
 }
 
-run().catch(err => {
+run().catch((err) => {
   if (err.code && err.code === 'EEXIST') {
     console.error(
       `${error} The name you specified already exists. Please pick a name that is not currently a directory name in this project`

--- a/_helpers/meta-template/assets/index.html
+++ b/_helpers/meta-template/assets/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Get started with your Twilio Functions!</title>
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
+    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
+    <style>
+      body {
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+      }
+
+      div[role="main"] {
+        flex: 1;
+      }
+
+      footer {
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Welcome to your new Twilio App</h1>
+    </header>
+    <div role="main">
+      <p>Now that your code is deployed, here are the last steps you need to do to finish your app.</p>
+      <ol>
+        <li>Make sure the Twilio phone number you want your app has a messaging webhook configured to point at
+        </li>
+        <p>
+          <pre><code><span class="function-root"></span>/hello-messaging</code></pre>
+        </p>
+        <li>Text anything to your Twilio app</li>
+        <li>You should receive a response saying "Hello World"</li>
+      </ol>
+    </div>
+    <footer>
+      <p>
+        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
+      </p>
+    </footer>
+
+    <script>
+      const baseUrl = new URL(location.href);
+      baseUrl.pathname = baseUrl
+        .pathname
+        .replace(/\/index\.html$/, '');
+      delete baseUrl.hash;
+      delete baseUrl.search;
+      const fullUrl = baseUrl
+        .href
+        .substr(0, baseUrl.href.length - 1);
+      const functionRoots = document.querySelectorAll('span.function-root');
+
+      functionRoots.forEach(element => {
+        element.innerText = fullUrl
+      })
+    </script>
+  </body>
+</html>

--- a/_helpers/meta-template/assets/index.html
+++ b/_helpers/meta-template/assets/index.html
@@ -47,6 +47,7 @@
     </footer>
 
     <script>
+      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
       const baseUrl = new URL(location.href);
       baseUrl.pathname = baseUrl
         .pathname

--- a/_helpers/meta-template/assets/index.html
+++ b/_helpers/meta-template/assets/index.html
@@ -22,6 +22,15 @@
       footer {
         text-align: center;
       }
+
+      footer p {
+        margin-bottom: 0;
+      }
+
+      #twilio-logo {
+        width: 50px;
+        height: 50px;
+      }
     </style>
   </head>
   <body>
@@ -52,6 +61,19 @@
       </section>
     </div>
     <footer>
+      <p>
+        <a href="https://www.twilio.com/">
+          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+            <defs>
+              <style>
+                .cls-1 {
+                  fill: #f22f46;
+                }
+              </style>
+            </defs>
+            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+        </a>
+      </p>
       <p>
         <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
       </p>

--- a/_helpers/meta-template/assets/index.html
+++ b/_helpers/meta-template/assets/index.html
@@ -29,16 +29,27 @@
       <h1>Welcome to your new Twilio App</h1>
     </header>
     <div role="main">
-      <p>Now that your code is deployed, here are the last steps you need to do to finish your app.</p>
-      <ol>
-        <li>Make sure the Twilio phone number you want your app has a messaging webhook configured to point at
-        </li>
-        <p>
-          <pre><code><span class="function-root"></span>/hello-messaging</code></pre>
-        </p>
-        <li>Text anything to your Twilio app</li>
-        <li>You should receive a response saying "Hello World"</li>
-      </ol>
+      <section>
+        <h3>Get started with your app</h3>
+        <p>Now that your code is deployed, here are the last steps you need to do to finish your app.</p>
+        <ol>
+          <li>Text anything to your Twilio app</li>
+          <li>You should receive a response saying "Hello World"</li>
+        </ol>
+      </section>
+      <section>
+        <h3>Troubleshooting</h3>
+        <ul>
+          <li>Make sure the Twilio phone number you want your app has a messaging webhook configured to point at
+          </li>
+          <p>
+            <pre><code><span class="function-root"></span>/hello-messaging</code></pre>
+          </p>
+          <li>Check the
+            <code>README.md</code>
+            of your project</li>
+        </ul>
+      </section>
     </div>
     <footer>
       <p>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -74,6 +74,12 @@ MY_PHONE_NUMBER=
 
 They should also be mentioned in the existing table inside the `README.md` of your template directory.
 
+### Updating the `index.html`
+
+If your app has a front-end component to it, you can override the existing `index.html` file in your project.
+
+In case your app does not contain a front-end component you should update the `index.html` file to reflect what steps a customer should perform to make the app work, once your template has been deployed.
+
 ### Testing the functionality of your new template locally
 
 1. Make sure you have the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart) installed.


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

This adds a new index.html template that we should use in every function template. It helps explain what last steps to do to set up and test your application. 

The current CSS makes use of milligram. I'll replace that once we have an equivalent that's powered by Paste.

## Description

<!-- a short description of your pull request -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
