### PR TITLE
fix(blocklist-call): change http method for redirect

### DIFF
--- a/blocklist-call/functions/blocklist-call.js
+++ b/blocklist-call/functions/blocklist-call.js
@@ -15,7 +15,9 @@ exports.handler = function (context, event, callback) {
     twiml.reject();
   } else {
     // Update this line to your response.
-    twiml.redirect('https://demo.twilio.com/docs/voice.xml');
+    twiml.redirect({
+      method: 'GET'
+    },'https://demo.twilio.com/docs/voice.xml');
   }
   callback(null, twiml);
 };


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description
URL does not support POST, so it was returning 404 page, which looked like invalid TwiML.
<!-- a short description of your pull request -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
