### PR TITLE
fix(templates/sip-quickstart) redirect to admin page prior to init

### DIFF
--- a/blocklist-call/functions/blocklist-call.js
+++ b/blocklist-call/functions/blocklist-call.js
@@ -15,7 +15,9 @@ exports.handler = function (context, event, callback) {
     twiml.reject();
   } else {
     // Update this line to your response.
-    twiml.redirect('https://demo.twilio.com/docs/voice.xml');
+    twiml.redirect({
+      method: 'GET'
+    },'https://demo.twilio.com/docs/voice.xml');
   }
   callback(null, twiml);
 };

--- a/sip-quickstart/assets/admin/index.html
+++ b/sip-quickstart/assets/admin/index.html
@@ -8,7 +8,7 @@
       <div class="login" v-if="!adminClient.isReady">
         <h1>Password required</h1>
         <p>
-          A password is required to update your environment. This can be found in the <code>.env</code>file in the root of your application. 
+          A password is required to update your environment. This can be found in your environment variables.
         </p>
         <form @submit.prevent="login">
           <div>

--- a/sip-quickstart/assets/index.html
+++ b/sip-quickstart/assets/index.html
@@ -55,7 +55,14 @@
           }
         },
         created() {
-          this.refreshConfiguration();
+          this.refreshConfiguration()
+            .then(() => {
+              if (!this.configuration.initialized) {
+                alert(`You must first initialize this application. 
+                  You will now be redirected to the admin interface.`);
+                window.location.href = "./admin/index.html";
+              }
+            });
         }
       });
 

--- a/sip-quickstart/assets/index.html
+++ b/sip-quickstart/assets/index.html
@@ -51,18 +51,17 @@
         methods: {
           async refreshConfiguration() {
             const response = await fetch("./sip-configuration");
+            if (!response.ok) {
+              const message = "You must first initialize this application." +
+                  "  You will now be redirected to the admin interface.";
+              alert(message);
+              window.location.href = "./admin/index.html";
+            }
             this.configuration = await response.json();
           }
         },
         created() {
-          this.refreshConfiguration()
-            .then(() => {
-              if (!this.configuration.initialized) {
-                alert(`You must first initialize this application. 
-                  You will now be redirected to the admin interface.`);
-                window.location.href = "./admin/index.html";
-              }
-            });
+          this.refreshConfiguration();
         }
       });
 

--- a/sip-quickstart/functions/sip-configuration.js
+++ b/sip-quickstart/functions/sip-configuration.js
@@ -2,19 +2,23 @@ const assets = Runtime.getAssets();
 const extensions = require(assets["/extensions.js"].path);
 
 exports.handler = async (context, event, callback) => {
-  const client = context.getTwilioClient();
-  const sipDomain = await client.sip.domains(context.SIP_DOMAIN_SID).fetch();
-  const localizedSipDomainName = sipDomain.domainName.replace(
-    ".sip.twilio.com",
-    ".sip.us1.twilio.com"
-  );
-  callback(null, {
-    initialized: context.INITIALIZED,
-    appName: context.APP_NAME,
-    incomingNumber: context.INCOMING_NUMBER,
-    callerId: context.CALLER_ID,
-    sipDomainName: sipDomain.domainName,
-    extensions,
-    localizedSipDomainName,
-  });
+  try {
+    const client = context.getTwilioClient();
+    const sipDomain = await client.sip.domains(context.SIP_DOMAIN_SID).fetch();
+    const localizedSipDomainName = sipDomain.domainName.replace(
+      ".sip.twilio.com",
+      ".sip.us1.twilio.com"
+    );
+    callback(null, {
+      initialized: context.INITIALIZED,
+      appName: context.APP_NAME,
+      incomingNumber: context.INCOMING_NUMBER,
+      callerId: context.CALLER_ID,
+      sipDomainName: sipDomain.domainName,
+      extensions,
+      localizedSipDomainName,
+    });
+  } catch(err) {
+    callback(err);
+  }
 };

--- a/sip-quickstart/functions/sip-configuration.js
+++ b/sip-quickstart/functions/sip-configuration.js
@@ -9,6 +9,7 @@ exports.handler = async (context, event, callback) => {
     ".sip.us1.twilio.com"
   );
   callback(null, {
+    initialized: context.INITIALIZED,
     appName: context.APP_NAME,
     incomingNumber: context.INCOMING_NUMBER,
     callerId: context.CALLER_ID,


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description
The /index.html route on SIP Quickstart requires initialization first. This change alerts and redirects.

<!-- a short description of your pull request -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
