### PR TITLE
feat(templates): add voice-queue template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8768,9 +8768,9 @@
       }
     },
     "@types/express": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
-      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
+      "version": "4.17.8",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz",
+      "integrity": "sha512-wLhcKh3PMlyA2cNAB9sjM1BntnhPMiM0JOBwPBqttjHev2428MLEB4AYVN+d8s2iyCVZac+o41Pflm/ZH5vLXQ==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
@@ -8780,9 +8780,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.6.tgz",
-      "integrity": "sha512-U2oynuRIB17GIbEdvjFrrEACOy7GQkzsX7bPEBz1H41vZYEU4j0fLL97sawmHDwHUXpUQDBMHIyM9vejqP9o1A==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz",
+      "integrity": "sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -8816,9 +8816,9 @@
       }
     },
     "@types/mime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
+      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
       "dev": true
     },
     "@types/node": {
@@ -8834,9 +8834,9 @@
       "dev": true
     },
     "@types/qs": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.2.tgz",
-      "integrity": "sha512-a9bDi4Z3zCZf4Lv1X/vwnvbbDYSNz59h3i3KdyuYYN+YrLjSeJD0dnphdULDfySvUv6Exy/O0K6wX/kQpnPQ+A==",
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ==",
       "dev": true
     },
     "@types/range-parser": {
@@ -8846,13 +8846,13 @@
       "dev": true
     },
     "@types/serve-static": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
-      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.6.tgz",
+      "integrity": "sha512-nuRJmv7jW7VmCVTn+IgYDkkbbDGyIINOeu/G0d74X3lm6E5KfMeQPJhxIt1ayQeQB3cSxvYs1RA/wipYoFB4EA==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
+        "@types/mime": "*",
+        "@types/node": "*"
       }
     },
     "@types/stack-utils": {
@@ -9965,9 +9965,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.8.26",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.26.tgz",
-      "integrity": "sha512-KqtAuIfdNfZR5sJY1Dixr2Is4ZvcCqhb0dZpCOt5dGEFiMzoIbjkTSzUb4QKTCsP+WNpGwUjAFIZrnZvUxxkhw==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.9.3.tgz",
+      "integrity": "sha512-V+1SyIvkS+HmNbN1G7A9+ERbFTV9KTXu6Oor98v2xHmzzpp52OIJhQuJSTywWuBY5pyAEmlwbCi1Me87n/SLOw==",
       "dev": true
     },
     "debug": {
@@ -14224,9 +14224,9 @@
       "dev": true
     },
     "querystringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true
     },
     "react-is": {
@@ -15335,24 +15335,31 @@
       "dev": true
     },
     "twilio": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.43.0.tgz",
-      "integrity": "sha512-PAF4mLpoGmWvpqSSQHNz/RGqkW/vwxjywsoDadQF599fztUmX0ETWcKxXe2N32KUObTUdUQRqjhhETSmXYkZiA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.50.0.tgz",
+      "integrity": "sha512-h/eWbi8YxdSBE6YgNfBHSDAYEhGUqGBrfqpaz4SF87MJQvygwSlfRvNA7WMajblQFP7Y68JqR20FFOjcYV3KJg==",
       "dev": true,
       "requires": {
-        "@types/express": "^4.17.3",
+        "@types/express": "^4.17.7",
+        "@types/qs": "6.9.4",
         "axios": "^0.19.2",
-        "dayjs": "^1.8.21",
+        "dayjs": "^1.8.29",
         "jsonwebtoken": "^8.5.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.19",
         "q": "2.0.x",
-        "qs": "^6.9.1",
+        "qs": "^6.9.4",
         "rootpath": "^0.1.2",
         "scmp": "^2.1.0",
         "url-parse": "^1.4.7",
         "xmlbuilder": "^13.0.2"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
         "qs": {
           "version": "6.9.4",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "log-symbols": "^3.0.0",
     "moment": "^2.24.0",
     "stripe": "^8.20.0",
-    "twilio": "^3.43.0"
+    "twilio": "^3.50.0"
   },
   "jest": {
     "testEnvironment": "node",

--- a/templates.json
+++ b/templates.json
@@ -209,6 +209,11 @@
       "id": "verify-dashboard",
       "name": "Verify Testing Dashboard",
       "description": "Helpful dashboard for testing and debugging during your development with Twilio Verify."
+    },
+    {
+      "id": "voice-queue",
+      "name": "Voice Queue with hold music",
+      "description": "Inbound calls are queued, and hold music is played until the intended recipient answers the call."
     }
   ]
 }

--- a/voice-queue/.env
+++ b/voice-queue/.env
@@ -1,0 +1,14 @@
+# description: The URL for the hold music you want to play. The default is classic.mp3.
+# format: url
+# required: true
+HOLD_MUSIC_URL=https://demo.twilio.com/docs/classic.mp3
+
+# description: Your personal number to forward the inbound caller to.
+# format: phone_number
+# required: true
+YOUR_PHONE_NUMBER=+12223334444
+
+# description: The Twilio number used to forward the call.
+# format: phone_number
+# required: true
+TWILIO_PHONE_NUMBER=+15555555555

--- a/voice-queue/README.md
+++ b/voice-queue/README.md
@@ -1,0 +1,61 @@
+# Voice Queue
+
+A simple call queuing system. Place the inbound caller into a queue with hold music while waiting for the intended recipient to answer.
+
+## Pre-requisites
+
+### Environment variables
+
+This project requires some environment variables to be set. To keep your tokens and secrets secure, make sure to not commit the `.env` file in git. When setting up the project with `twilio serverless:init ...` the Twilio CLI will create a `.gitignore` file that excludes `.env` from the version history.
+
+In your `.env` file, set the following values:
+
+| Variable              | Description                                          | Required |
+| :-------------------- | :--------------------------------------------------- | :------- |
+| `HOLD_MUSIC_URL`      | The URL for the hold music you want to play.         | true     |
+| `YOUR_PHONE_NUMBER`   | Your personal number to forward the inbound call to. | true     |
+| `TWILIO_PHONE_NUMBER` | The Twilio number used to forward the call.          | true     |
+
+### Function Parameters
+
+`/dial-queue` expects the following parameters:
+
+| Parameter | Description                                                     | Required |
+| :-------- | :-------------------------------------------------------------- | :------- |
+| `CallSid` | Use the inbound CallSid as the unique identifier for the Queue. | true     |
+| `From`    | Whisper who is calling to the intended recipient.               | true     |
+
+## Create a new project with the template
+
+1. Install the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart#install-twilio-cli)
+2. Install the [serverless toolkit](https://www.twilio.com/docs/labs/serverless-toolkit/getting-started)
+
+```shell
+twilio plugins:install @twilio-labs/plugin-serverless
+```
+
+3. Initiate a new project
+
+```
+twilio serverless:init example --template=call-queue && cd example
+```
+
+4. Start the server with the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart):
+
+```
+twilio serverless:start
+```
+
+5. Open the web page at https://localhost:3000/index.html and enter your phone number to test
+
+ℹ️ Check the developer console and terminal for any errors, make sure you've set your environment variables.
+
+## Deploying
+
+Deploy your functions and assets with either of the following commands. Note: you must run these commands from inside your project folder. [More details in the docs.](https://www.twilio.com/docs/labs/serverless-toolkit)
+
+With the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart):
+
+```
+twilio serverless:deploy
+```

--- a/voice-queue/README.md
+++ b/voice-queue/README.md
@@ -37,7 +37,7 @@ twilio plugins:install @twilio-labs/plugin-serverless
 3. Initiate a new project
 
 ```
-twilio serverless:init example --template=call-queue && cd example
+twilio serverless:init example --template=voice-queue && cd voice-queue
 ```
 
 4. Start the server with the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart):

--- a/voice-queue/assets/index.html
+++ b/voice-queue/assets/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Get started with your Twilio Functions!</title>
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
+    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
+    <style>
+      body {
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+      }
+
+      div[role="main"] {
+        flex: 1;
+      }
+
+      footer {
+        text-align: center;
+      }
+
+      footer p {
+        margin-bottom: 0;
+      }
+
+      #twilio-logo {
+        width: 50px;
+        height: 50px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Welcome to your new Twilio App</h1>
+    </header>
+    <div role="main">
+      <section>
+        <h3>Get started with your app</h3>
+        <p>Now that your code is deployed, here are the last steps you need to do to finish your app.</p>
+        <ol>
+          <li>Have anyone call your Twilio app.</li>
+          <li>The caller will hear music while they are on hold.</li>
+          <li>An outbound call will dial your personal number, and connect you to the initiated caller.</li>
+        </ol>
+      </section>
+      <section>
+        <h3>Troubleshooting</h3>
+        <ul>
+          <li>Make sure the Twilio phone number you want your app has a voice webhook configured to point at
+          </li>
+          <p>
+            <pre><code><span class="function-root"></span>/enqueue</code></pre>
+          </p>
+          <li>Check the
+            <code>README.md</code>
+            of your project</li>
+        </ul>
+      </section>
+    </div>
+    <footer>
+      <p>
+        <a href="https://www.twilio.com/">
+          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+            <defs>
+              <style>
+                .cls-1 {
+                  fill: #f22f46;
+                }
+              </style>
+            </defs>
+            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+        </a>
+      </p>
+      <p>
+        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
+      </p>
+    </footer>
+
+    <script>
+      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
+      const baseUrl = new URL(location.href);
+      baseUrl.pathname = baseUrl
+        .pathname
+        .replace(/\/index\.html$/, '');
+      delete baseUrl.hash;
+      delete baseUrl.search;
+      const fullUrl = baseUrl
+        .href
+        .substr(0, baseUrl.href.length - 1);
+      const functionRoots = document.querySelectorAll('span.function-root');
+
+      functionRoots.forEach(element => {
+        element.innerText = fullUrl
+      })
+    </script>
+  </body>
+</html>

--- a/voice-queue/functions/dial-queue.protected.js
+++ b/voice-queue/functions/dial-queue.protected.js
@@ -1,0 +1,22 @@
+exports.handler = function (context, event, callback) {
+  const fromSid = event.fromCallSid;
+  // If no fromSid is set, error out.
+  if (!fromSid) {
+    return callback({
+      status: 500,
+      message: 'No CallSid found. Inbound voice webhook should be set to /enqueue'
+    }, null);
+  }
+
+  // Split the phone number out so that <Say> reads every number when identifying the caller.
+  const from = event.from;
+  const fromFormatted = from.split('').join(' ');
+
+  // Announce who is calling.
+  const response = new Twilio.twiml.VoiceResponse();
+  response.say(`You have an incoming call from ${fromFormatted}`);
+  // Dial into the queue where the initiated caller is waiting.
+  response.dial().queue(fromSid);
+
+  callback(null, response);
+};

--- a/voice-queue/functions/enqueue.protected.js
+++ b/voice-queue/functions/enqueue.protected.js
@@ -1,0 +1,23 @@
+exports.handler = function (context, event, callback) {
+  const { CallSid, From } = event;
+
+  if (From) {
+    const client = context.getTwilioClient();
+    const path = `https://${context.DOMAIN_NAME}`;
+    // Make an outbound call to your phone number to connect the two legs.
+    // Use the inbound CallSid as the unique identifier for the queue.
+    client.calls.create({
+      to: context.YOUR_PHONE_NUMBER,
+      from: context.TWILIO_PHONE_NUMBER,
+      url: `${path}/dial-queue?fromCallSid=${CallSid}&from=${From}`
+    });
+  }
+  // Enqueue the inbound caller.
+  // waitUrl points to an endpoint to <Play> the mp3 set in the env variables.
+  const response = new Twilio.twiml.VoiceResponse();
+  response.enqueue({
+    waitUrl: '/hold-music'
+  }, CallSid);
+
+  callback(null, response);
+};

--- a/voice-queue/functions/hold-music.protected.js
+++ b/voice-queue/functions/hold-music.protected.js
@@ -1,0 +1,6 @@
+exports.handler = function (context, event, callback) {
+  const response = new Twilio.twiml.VoiceResponse();
+  // HOLD_MUSIC_URL points to the audio file set in your environment variables.
+  response.play(context.HOLD_MUSIC_URL);
+  callback(null, response);
+};

--- a/voice-queue/package.json
+++ b/voice-queue/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "voice-queue",
+  "dependencies": {
+    "twilio": "^3.50.0"
+  }
+}

--- a/voice-queue/tests/dial-queue.protected.test.js
+++ b/voice-queue/tests/dial-queue.protected.test.js
@@ -1,0 +1,28 @@
+const helpers = require('../../test/test-helper');
+const dialQueue = require('../functions/dial-queue.protected').handler;
+
+const context = {};
+
+const event = {
+  fromCallSid: 'CAX',
+  from: '123'
+};
+
+beforeAll(() => {
+  helpers.setup(context);
+});
+
+afterAll(() => {
+  helpers.teardown();
+});
+
+test('returns a VoiceResponse with a Whisper and Queue with CallSid id', done => {
+  const callback = (err, result) => {
+  expect(result.toString()).toMatch(
+    '<Say>You have an incoming call from ' + event.from.split('').join(' ') + '</Say>' +
+    '<Dial><Queue>' + event.fromCallSid + '</Queue></Dial>')
+  done();
+};
+
+  dialQueue(context, event, callback);
+});

--- a/voice-queue/tests/enqueue.protected.test.js
+++ b/voice-queue/tests/enqueue.protected.test.js
@@ -1,0 +1,25 @@
+const helpers = require('../../test/test-helper');
+const enqueue = require('../functions/enqueue.protected').handler;
+
+const context = {};
+
+const event = {
+  CallSid: 'CAX',
+};
+
+beforeAll(() => {
+  helpers.setup(context);
+});
+
+afterAll(() => {
+  helpers.teardown();
+});
+
+test('returns a VoiceResponse with an Enqueue id', done => {
+  const callback = (err, result) => {
+    expect(result.toString()).toMatch('<Enqueue waitUrl="/hold-music">' + event.CallSid + '</Enqueue>');
+    done();
+  };
+
+  enqueue(context, event, callback);
+});

--- a/voice-queue/tests/hold-music.protected.test.js
+++ b/voice-queue/tests/hold-music.protected.test.js
@@ -1,0 +1,25 @@
+const helpers = require('../../test/test-helper');
+const holdMusic = require('../functions/hold-music.protected').handler;
+
+const context = {
+  HOLD_MUSIC_URL: 'https://demo.twilio.com/docs/classic.mp3'
+};
+
+const event = {};
+
+beforeAll(() => {
+  helpers.setup(context);
+});
+
+afterAll(() => {
+  helpers.teardown();
+});
+
+test('plays hold music', done => {
+  const callback = (err, result) => {
+    expect(result.toString()).toMatch('<Play>' + context.HOLD_MUSIC_URL + '</Play>');
+    done();
+  };
+
+  holdMusic(context, event, callback);
+});


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

**Add template**: voice-queue
**Template Description:** A simple call queuing system. Place the inbound caller into a queue with hold music while waiting for the intended recipient to answer.
## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

None
