### PR TITLE
feat(templates): Create a template Google Sheets integration

### DIFF
--- a/google-sheets/.env
+++ b/google-sheets/.env
@@ -1,3 +1,13 @@
+# description: The email for your Sheets service account, from the client_email field of its JSON key file
+# format: text
+# required: true
+SHEETS_CLIENT_EMAIL=
+
+# description: The private key for your Sheets service account, from the private_key field of its JSON key file
+# format: secret
+# required: true
+SHEETS_PRIVATE_KEY=
+
 # description: The document ID for your Google Sheets spreadsheet (from its URL: https://docs.google.com/spreadsheets/d/[id]/edit)
 # format: text
 # required: true
@@ -8,6 +18,6 @@ SHEETS_DOC_ID=
 # required: true
 SHEETS_SHEET_NAME=Sheet1
 
-# description: The path to your Google Cloud service account's authentication key file
+# description: The path to the webhook
 # configurable: false
-SHEETS_SERVICE_ACCOUNT_JSON=./assets/auth.json
+TWILIO_SMS_WEBHOOK_URL=/log-sms

--- a/google-sheets/.env
+++ b/google-sheets/.env
@@ -3,7 +3,7 @@
 # contentKey: SHEETS_AUTH_JSON_CONTENT
 # link: https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys
 # required: true
-SHEETS_AUTH_JSON=/assets/auth.private.json
+SHEETS_AUTH_JSON=/auth.json
 
 # description: The document ID for your Google Sheets spreadsheet (from its URL: https://docs.google.com/spreadsheets/d/[id]/edit)
 # format: text

--- a/google-sheets/.env
+++ b/google-sheets/.env
@@ -1,0 +1,13 @@
+# description: The document ID for your Google Sheets spreadsheet (from its URL: https://docs.google.com/spreadsheets/d/[id]/edit)
+# format: text
+# required: true
+SHEETS_DOC_ID=
+
+# description: The spreadsheet name to log to within your Google Sheets document
+# format: text
+# required: true
+SHEETS_SHEET_NAME=Sheet1
+
+# description: The path to your Google Cloud service account's authentication key file
+# configurable: false
+SHEETS_SERVICE_ACCOUNT_JSON=./assets/auth.json

--- a/google-sheets/.env
+++ b/google-sheets/.env
@@ -1,10 +1,12 @@
 # description: The email for your Sheets service account, from the client_email field of its JSON key file
 # format: text
+# link: https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys
 # required: true
 SHEETS_CLIENT_EMAIL=
 
 # description: The private key for your Sheets service account, from the private_key field of its JSON key file
 # format: secret
+# link: https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys
 # required: true
 SHEETS_PRIVATE_KEY=
 

--- a/google-sheets/.env
+++ b/google-sheets/.env
@@ -1,14 +1,9 @@
-# description: The email for your Sheets service account, from the client_email field of its JSON key file
-# format: text
+# description: A JSON key file for your Google Sheets service account
+# format: file(json)
+# contentKey: SHEETS_AUTH_JSON_CONTENT
 # link: https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys
 # required: true
-SHEETS_CLIENT_EMAIL=
-
-# description: The private key for your Sheets service account, from the private_key field of its JSON key file
-# format: secret
-# link: https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys
-# required: true
-SHEETS_PRIVATE_KEY=
+SHEETS_AUTH_JSON=/assets/auth.private.json
 
 # description: The document ID for your Google Sheets spreadsheet (from its URL: https://docs.google.com/spreadsheets/d/[id]/edit)
 # format: text

--- a/google-sheets/README.md
+++ b/google-sheets/README.md
@@ -17,20 +17,6 @@ In your `.env` file, set the following values:
 | SHEETS_DOC_ID     | The document ID for your Google Sheets spreadsheet                | Yes      |
 | SHEETS_SHEET_NAME | The spreadsheet name to log to within your Google Sheets document | Yes      |
 
-### Function Parameters
-
-`/blank` expects the following parameters:
-
-| Parameter | Description | Required |
-| :-------- | :---------- | :------- |
-
-
-`/hello-messaging` is protected and requires a valid Twilio signature as well as the following parameters:
-
-| Parameter | Description | Required |
-| :-------- | :---------- | :------- |
-
-
 ## Create a new project with the template
 
 1. Install the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart#install-twilio-cli)

--- a/google-sheets/README.md
+++ b/google-sheets/README.md
@@ -4,7 +4,7 @@ Logs incoming SMS numbers and messages into a Google Sheets spreadsheet.
 
 ## Pre-requisites
 
-To use this function, you will need a Google Sheets spreadsheet you want to log messages into, and a Google Cloud service account and associated authentication key. See the Google documentation on [creating a service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating) and [generating an authentication key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys) for details. Ensure that your authentication key is in JSON format, and that it is saved to a file named `auth.json` under the `assets` directory for this function.
+To use this function, you will need a Google Sheets spreadsheet you want to log messages into, and a Google Cloud service account and associated authentication key. See the Google documentation on [creating a service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating) and [generating an authentication key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys) for details. Ensure that your authentication key is in JSON format, and that it is saved to a file named `auth.private.json` under the `assets` directory for this function.
 
 ### Environment variables
 
@@ -14,6 +14,7 @@ In your `.env` file, set the following values:
 
 | Variable          | Description                                                       | Required |
 | :---------------- | :---------------------------------------------------------------- | :------- |
+| SHEETS_AUTH_JSON  | The path to your Google service account authentication JSON file  | Yes      |
 | SHEETS_DOC_ID     | The document ID for your Google Sheets spreadsheet                | Yes      |
 | SHEETS_SHEET_NAME | The spreadsheet name to log to within your Google Sheets document | Yes      |
 

--- a/google-sheets/README.md
+++ b/google-sheets/README.md
@@ -1,0 +1,67 @@
+# Google Sheets
+
+Logs incoming SMS numbers and messages into a Google Sheets spreadsheet.
+
+## Pre-requisites
+
+To use this function, you will need a Google Sheets spreadsheet you want to log messages into, and a Google Cloud service account and associated authentication key. See the Google documentation on [creating a service account](https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating) and [generating an authentication key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys) for details. Ensure that your authentication key is in JSON format, and that it is saved to a file named `auth.json` under the `assets` directory for this function.
+
+### Environment variables
+
+This project requires some environment variables to be set. To keep your tokens and secrets secure, make sure to not commit the `.env` file in git. When setting up the project with `twilio serverless:init ...` the Twilio CLI will create a `.gitignore` file that excludes `.env` from the version history.
+
+In your `.env` file, set the following values:
+
+| Variable          | Description                                                       | Required |
+| :---------------- | :---------------------------------------------------------------- | :------- |
+| SHEETS_DOC_ID     | The document ID for your Google Sheets spreadsheet                | Yes      |
+| SHEETS_SHEET_NAME | The spreadsheet name to log to within your Google Sheets document | Yes      |
+
+### Function Parameters
+
+`/blank` expects the following parameters:
+
+| Parameter | Description | Required |
+| :-------- | :---------- | :------- |
+
+
+`/hello-messaging` is protected and requires a valid Twilio signature as well as the following parameters:
+
+| Parameter | Description | Required |
+| :-------- | :---------- | :------- |
+
+
+## Create a new project with the template
+
+1. Install the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart#install-twilio-cli)
+2. Install the [serverless toolkit](https://www.twilio.com/docs/labs/serverless-toolkit/getting-started)
+
+```shell
+twilio plugins:install @twilio-labs/plugin-serverless
+```
+
+3. Initiate a new project
+
+```
+twilio serverless:init example --template=google-sheets && cd example
+```
+
+4. Start the server with the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart):
+
+```
+twilio serverless:start
+```
+
+5. Open the web page at https://localhost:3000/index.html and follow the instructions to test your application.
+
+ℹ️ Check the developer console and terminal for any errors, make sure you've set your environment variables.
+
+## Deploying
+
+Deploy your functions and assets with either of the following commands. Note: you must run these commands from inside your project folder. [More details in the docs.](https://www.twilio.com/docs/labs/serverless-toolkit)
+
+With the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart):
+
+```
+twilio serverless:deploy
+```

--- a/google-sheets/assets/auth.private.json
+++ b/google-sheets/assets/auth.private.json
@@ -1,0 +1,1 @@
+["replace the contents of this file with your Google service account key file"]

--- a/google-sheets/assets/auth.private.json
+++ b/google-sheets/assets/auth.private.json
@@ -1,1 +1,12 @@
-["replace the contents of this file with your Google service account key file"]
+{
+  "type": "service_account",
+  "project_id": "<YOUR PROJECT ID HERE>",
+  "private_key_id": "<YOUR PRIVATE KEY ID HERE>",
+  "private_key": "<YOUR PRIVATE KEY BLOCK HERE>",
+  "client_email": "<YOUR SERVICE ACCOUNT EMAIL ADDRESS>",
+  "client_id": "<YOUR CLIENT ID>",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "<YOUR X509 CERT URL>"
+}

--- a/google-sheets/assets/index.html
+++ b/google-sheets/assets/index.html
@@ -69,13 +69,17 @@
                         Now that your code is deployed, here are the last steps you need to do to finish your app.
                     </p>
                     <p>
-                        This app automatically logs texts to your phone number into the specified
-                        Google Sheets document.
+                        This app automatically logs text messages sent to your Twilio phone number into the
+                        specified Google Sheets document.
                     </p>
                     <ol class="steps">
+                        <li>Open the Google Sheets document whose ID you configured for use with this app.</li>
                         <li>
-                            Share your Google Sheets document with the email address of your Google Sheets
-                            service account.
+                            Click the <b>Share</b> button in the toolbar of your Google Sheets document, enter the
+                            <a href="https://console.cloud.google.com/iam-admin/serviceaccounts">
+                                email address belonging to your service account
+                            </a>, and press Enter to give your service account access to your Google Sheets
+                            document.
                         </li>
                         <li>Text your Twilio phone number with a message.</li>
                         <li>

--- a/google-sheets/assets/index.html
+++ b/google-sheets/assets/index.html
@@ -42,19 +42,7 @@
         <h3>Get started with your app</h3>
         <p>This app automatically logs texts to your phone number into the specified Google Sheets document. Follow the steps below to test your app:</p>
         <ol>
-          <li>
-              <a href="https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating">
-                  Create a Google Cloud service account
-              </a>
-              to allow this app to add to your spreadsheet.
-          </li>
-          <li>
-            <a href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys">
-              Generate keys for your Google Cloud service account in JSON format
-            </a>
-            and save the resulting file as <code>auth.json</code> under this app's <code>assets</code> directory.
-          </li>
-          <li>Share your Google Sheets document with the email address of the service account.</li>
+          <li>Share your Google Sheets document with the email address of your Google Sheets service account.</li>
           <li>Text your Twilio phone number with a message.</li>
           <li>Your spreadsheet should now contain the SID, phone number, and content of the text you sent.</li>
         </ol>
@@ -67,9 +55,10 @@
               <pre><code><span class="function-root"></span>/log-sms</code></pre>
             </p>
           </li>
-          <li>Ensure that you have created a Google service account, saved its private key as <code>auth.json</code> in your function's assets, and shared the spreadsheet you want to log into with that service account's email address as an Editor.</li>
+          <li>Ensure that you have created a Google service account, and that <code>SHEETS_CLIENT_EMAIL</code> and <code>SHEETS_PRIVATE_KEY</code> contain the values from the <code>client_email</code> and <code>private_key</code> fields of its JSON key file, respectively.</li>
         </ul>
       </section>
+      <!-- APP_INFO -->
     </div>
     <footer>
       <p>

--- a/google-sheets/assets/index.html
+++ b/google-sheets/assets/index.html
@@ -31,6 +31,18 @@
         width: 50px;
         height: 50px;
       }
+
+      #check-status {
+        padding: 1em;
+      }
+
+      .status-success {
+        color: darkgreen;
+      }
+
+      .status-failure {
+        color: maroon;
+      }
     </style>
   </head>
   <body>
@@ -50,6 +62,14 @@
       <section>
         <h3>Troubleshooting</h3>
         <ul>
+          <li>
+            Verify your Google Sheets configuration:
+            <div id="check-status">
+              <button onclick="showGoogleSheetsStatus()">Verify Configuration</button>
+              <span id="status-message"></span>
+            </div>
+            If the above check reveals problems, edit this function's <code>.env</code> file via the <code>Edit This Code</code> button below, if available, and ensure that all values are correct.
+          </li>
           <li>Check the <a href="https://www.twilio.com/console/phone-numbers/incoming">phone number configuration</a> and make sure the Twilio phone number you want your app has an SMS webhook configured to point at
             <p>
               <pre><code><span class="function-root"></span>/log-sms</code></pre>
@@ -97,4 +117,25 @@
       })
     </script>
   </body>
+  <script>
+   async function showGoogleSheetsStatus() {
+       const message = document.getElementById('status-message');
+
+       message.className = '';
+       message.textContent = 'Checking Google Sheets status...';
+
+       try {
+           const res = await fetch('./check-sheets-config', {
+               method: 'POST',
+           });
+           const resData = await res.json();
+
+           message.className = resData.success ? 'status-success' : 'status-failure';
+           message.textContent = resData.message;
+       } catch (err) {
+           message.className = 'status-failure';
+           message.textContent = `Google Sheets error: ${err}`;
+       }
+   }
+  </script>
 </html>

--- a/google-sheets/assets/index.html
+++ b/google-sheets/assets/index.html
@@ -12,6 +12,10 @@
          async function showGoogleSheetsStatus() {
              const message = document.getElementById('status-message');
 
+             if(!message) {
+                 throw new Error('Missing "status-message" element');
+             }
+
              message.className = '';
              message.textContent = 'Checking Google Sheets status...';
 
@@ -76,7 +80,8 @@
                         <li>Open the Google Sheets document whose ID you configured for use with this app.</li>
                         <li>
                             Click the <b>Share</b> button in the toolbar of your Google Sheets document, enter the
-                            <a href="https://console.cloud.google.com/iam-admin/serviceaccounts">
+                            <a href="https://console.cloud.google.com/iam-admin/serviceaccounts"
+                               target="_blank" rel="noopener">
                                 email address belonging to your service account
                             </a>, and press Enter to give your service account access to your Google Sheets
                             document.

--- a/google-sheets/assets/index.html
+++ b/google-sheets/assets/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Get started with your Twilio Functions!</title>
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
+    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
+    <style>
+      body {
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+      }
+
+      div[role="main"] {
+        flex: 1;
+      }
+
+      footer {
+        text-align: center;
+      }
+
+      footer p {
+        margin-bottom: 0;
+      }
+
+      #twilio-logo {
+        width: 50px;
+        height: 50px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Welcome to your new Twilio App</h1>
+    </header>
+    <div role="main">
+      <section>
+        <h3>Get started with your app</h3>
+        <p>This app automatically logs texts to your phone number into the specified Google Sheets document. Follow the steps below to test your app:</p>
+        <ol>
+          <li>
+              <a href="https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating">
+                  Create a Google Cloud service account
+              </a>
+              to allow this app to add to your spreadsheet.
+          </li>
+          <li>
+            <a href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys">
+              Generate keys for your Google Cloud service account in JSON format
+            </a>
+            and save the resulting file as <code>auth.json</code> under this app's <code>assets</code> directory.
+          </li>
+          <li>Share your Google Sheets document with the email address of the service account.</li>
+          <li>Text your Twilio phone number with a message.</li>
+          <li>Your spreadsheet should now contain the SID, phone number, and content of the text you sent.</li>
+        </ol>
+      </section>
+      <section>
+        <h3>Troubleshooting</h3>
+        <ul>
+          <li>Check the <a href="https://www.twilio.com/console/phone-numbers/incoming">phone number configuration</a> and make sure the Twilio phone number you want your app has an SMS webhook configured to point at
+            <p>
+              <pre><code><span class="function-root"></span>/log-sms</code></pre>
+            </p>
+          </li>
+          <li>Ensure that you have created a Google service account, saved its private key as <code>auth.json</code> in your function's assets, and shared the spreadsheet you want to log into with that service account's email address as an Editor.</li>
+        </ul>
+      </section>
+    </div>
+    <footer>
+      <p>
+        <a href="https://www.twilio.com/">
+          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+            <defs>
+              <style>
+                .cls-1 {
+                  fill: #f22f46;
+                }
+              </style>
+            </defs>
+            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+        </a>
+      </p>
+      <p>
+        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
+      </p>
+    </footer>
+
+    <script>
+      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
+      const baseUrl = new URL(location.href);
+      baseUrl.pathname = baseUrl
+        .pathname
+        .replace(/\/index\.html$/, '');
+      delete baseUrl.hash;
+      delete baseUrl.search;
+      const fullUrl = baseUrl
+        .href
+        .substr(0, baseUrl.href.length - 1);
+      const functionRoots = document.querySelectorAll('span.function-root');
+
+      functionRoots.forEach(element => {
+        element.innerText = fullUrl
+      })
+    </script>
+  </body>
+</html>

--- a/google-sheets/assets/index.html
+++ b/google-sheets/assets/index.html
@@ -1,141 +1,133 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Get started with your Twilio Functions!</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
-    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
-    <style>
-      body {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
 
-      div[role="main"] {
-        flex: 1;
-      }
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+        <script>
+         async function showGoogleSheetsStatus() {
+             const message = document.getElementById('status-message');
 
-      footer {
-        text-align: center;
-      }
+             message.className = '';
+             message.textContent = 'Checking Google Sheets status...';
 
-      footer p {
-        margin-bottom: 0;
-      }
+             try {
+                 const res = await fetch('./check-sheets-config', {
+                     method: 'POST',
+                 });
+                 const resData = await res.json();
 
-      #twilio-logo {
-        width: 50px;
-        height: 50px;
-      }
+                 message.className = resData.success ? 'status-success' : 'status-failure';
+                 message.textContent = resData.message;
+             } catch (err) {
+                 message.className = 'status-failure';
+                 message.textContent = `Google Sheets error: ${err}`;
+             }
+         }
+        </script>
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This app automatically logs texts to your phone number into the specified
+                        Google Sheets document.
+                    </p>
+                    <ol class="steps">
+                        <li>
+                            Share your Google Sheets document with the email address of your Google Sheets
+                            service account.
+                        </li>
+                        <li>Text your Twilio phone number with a message.</li>
+                        <li>
+                            Your spreadsheet should now contain the SID, phone number, and content of
+                            the text you sent.
+                        </li>
+                    </ol>
+                </section>
 
-      #check-status {
-        padding: 1em;
-      }
-
-      .status-success {
-        color: darkgreen;
-      }
-
-      .status-failure {
-        color: maroon;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Welcome to your new Twilio App</h1>
-    </header>
-    <div role="main">
-      <section>
-        <h3>Get started with your app</h3>
-        <p>This app automatically logs texts to your phone number into the specified Google Sheets document. Follow the steps below to test your app:</p>
-        <ol>
-          <li>Share your Google Sheets document with the email address of your Google Sheets service account.</li>
-          <li>Text your Twilio phone number with a message.</li>
-          <li>Your spreadsheet should now contain the SID, phone number, and content of the text you sent.</li>
-        </ol>
-      </section>
-      <section>
-        <h3>Troubleshooting</h3>
-        <ul>
-          <li>
-            Verify your Google Sheets configuration:
-            <div id="check-status">
-              <button onclick="showGoogleSheetsStatus()">Verify Configuration</button>
-              <span id="status-message"></span>
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <p>
+                            <li>
+                                Verify your Google Sheets configuration:
+                                <div id="check-status">
+                                    <button onclick="showGoogleSheetsStatus()">Verify Configuration</button>
+                                    <span id="status-message"></span>
+                                </div>
+                                If the above check reveals problems, edit this function's <code>.env</code> file via the <code>Edit This Code</code> button above, if available, and ensure that all values are correct.
+                            </li>
+                        </p>
+                        <p>
+                            If you see "Google Sheets integration error: The caller does not have permission" in your
+                            Twilio console debugger, ensure you have shared your Google Sheets document with the email
+                            address associated with your Service Account.
+                        </p>
+                        <p>
+                            <li>
+                                Check the
+                                <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                                   target="_blank"
+                                   rel="noopener">
+                                    phone number configuration
+                                </a>
+                                and make sure the Twilio phone number you want for your app has a SMS webhook
+                                configured to point at the following URL
+                                <form>
+                                    <label for="twilio-webhook">Webhook URL</label>
+                                    <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/google-sheets">
+                                </form>
+                            </li>
+                        </p>
+                    </ul>
+                </section>
             </div>
-            If the above check reveals problems, edit this function's <code>.env</code> file via the <code>Edit This Code</code> button below, if available, and ensure that all values are correct.
-          </li>
-          <li>Check the <a href="https://www.twilio.com/console/phone-numbers/incoming">phone number configuration</a> and make sure the Twilio phone number you want your app has an SMS webhook configured to point at
-            <p>
-              <pre><code><span class="function-root"></span>/log-sms</code></pre>
-            </p>
-          </li>
-          <li>Ensure that you have created a Google service account, and that <code>SHEETS_CLIENT_EMAIL</code> and <code>SHEETS_PRIVATE_KEY</code> contain the values from the <code>client_email</code> and <code>private_key</code> fields of its JSON key file, respectively.</li>
-        </ul>
-      </section>
-      <!-- APP_INFO -->
-    </div>
-    <footer>
-      <p>
-        <a href="https://www.twilio.com/">
-          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
-            <defs>
-              <style>
-                .cls-1 {
-                  fill: #f22f46;
-                }
-              </style>
-            </defs>
-            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
-        </a>
-      </p>
-      <p>
-        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
-      </p>
-    </footer>
-
-    <script>
-      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
-      const baseUrl = new URL(location.href);
-      baseUrl.pathname = baseUrl
-        .pathname
-        .replace(/\/index\.html$/, '');
-      delete baseUrl.hash;
-      delete baseUrl.search;
-      const fullUrl = baseUrl
-        .href
-        .substr(0, baseUrl.href.length - 1);
-      const functionRoots = document.querySelectorAll('span.function-root');
-
-      functionRoots.forEach(element => {
-        element.innerText = fullUrl
-      })
-    </script>
-  </body>
-  <script>
-   async function showGoogleSheetsStatus() {
-       const message = document.getElementById('status-message');
-
-       message.className = '';
-       message.textContent = 'Checking Google Sheets status...';
-
-       try {
-           const res = await fetch('./check-sheets-config', {
-               method: 'POST',
-           });
-           const resData = await res.json();
-
-           message.className = resData.success ? 'status-success' : 'status-failure';
-           message.textContent = resData.message;
-       } catch (err) {
-           message.className = 'status-failure';
-           message.textContent = `Google Sheets error: ${err}`;
-       }
-   }
-  </script>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
 </html>

--- a/google-sheets/functions/check-sheets-config.js
+++ b/google-sheets/functions/check-sheets-config.js
@@ -1,12 +1,22 @@
 const { google } = require('googleapis');
-const path = require('path');
+
+const isAuthValid = (authJson) =>
+      authJson.client_email &&
+      authJson.client_email !== "<YOUR SERVICE ACCOUNT EMAIL ADDRESS>" &&
+      authJson.private_key &&
+      authJson.private_key !== "<YOUR PRIVATE KEY BLOCK HERE>";
 
 exports.handler = async function(context, _event, callback) {
     const response = new Twilio.Response();
     response.appendHeader('Content-Type', 'application/json');
 
     try {
-        const authJson = require(path.join('..', context.SHEETS_AUTH_JSON));
+        const authJson = require(Runtime.getAssets()[context.SHEETS_AUTH_JSON].path);
+
+        if(!isAuthValid(authJson)) {
+            throw new Error('Invalid authentication JSON file');
+        }
+
         const auth = new google.auth.JWT({
             email: authJson.client_email,
             key: authJson.private_key,

--- a/google-sheets/functions/check-sheets-config.js
+++ b/google-sheets/functions/check-sheets-config.js
@@ -1,0 +1,47 @@
+const { google } = require('googleapis');
+
+exports.handler = async function(context, _event, callback) {
+    const response = new Twilio.Response();
+    response.appendHeader('Content-Type', 'application/json');
+
+    try {
+        const auth = new google.auth.JWT(
+            context.SHEETS_CLIENT_EMAIL,
+            null,
+            context.SHEETS_PRIVATE_KEY.replace(/\\n/g, '\n'),
+            [ 'https://www.googleapis.com/auth/spreadsheets' ],
+        );
+        const sheets = google.sheets({
+            version: 'v4',
+            auth,
+        });
+
+        await sheets.spreadsheets.values.get({
+            spreadsheetId: context.SHEETS_DOC_ID,
+            range: `'${context.SHEETS_SHEET_NAME}'`,
+        });
+
+        response.setStatusCode(200);
+        response.setBody({
+            success: true,
+            message: 'Google Sheets integration is configured properly.',
+        });
+        callback(null, response);
+    } catch (error) {
+        let message = `Google Sheets integration error: ${error.message || error}`;
+
+        if (error.code === 404) {
+            message = 'Could not find your Google Sheets document. Please ensure SHEETS_DOC_ID is correct.';
+        }
+        else if (error.code === 400 && error.errors && error.errors[0] && error.errors[0].message) {
+            message = `Google sheets error: ${error.errors[0].message}. Please ensure SHEETS_SHEET_NAME is a valid spreadsheet inside your document.`;
+        }
+
+        response.setStatusCode(400);
+        response.setBody({
+            success: false,
+            message,
+        });
+        callback(null, response);
+    }
+}

--- a/google-sheets/functions/check-sheets-config.js
+++ b/google-sheets/functions/check-sheets-config.js
@@ -1,4 +1,5 @@
 const { google } = require('googleapis');
+const fs = require('fs').promises;
 
 const isAuthValid = (authJson) =>
       authJson.client_email &&
@@ -11,7 +12,8 @@ exports.handler = async function(context, _event, callback) {
     response.appendHeader('Content-Type', 'application/json');
 
     try {
-        const authJson = require(Runtime.getAssets()[context.SHEETS_AUTH_JSON].path);
+        const authJson = JSON.parse(await fs.readFile(
+            Runtime.getAssets()[context.SHEETS_AUTH_JSON].path));
 
         if(!isAuthValid(authJson)) {
             throw new Error('Invalid authentication JSON file');

--- a/google-sheets/functions/check-sheets-config.js
+++ b/google-sheets/functions/check-sheets-config.js
@@ -41,13 +41,16 @@ exports.handler = async function(context, _event, callback) {
         });
         callback(null, response);
     } catch (error) {
-        let message = `Google Sheets integration error: ${error.message || error}`;
+        let message = 'Google Sheets integration error. Please check the debugger in your Twilio Console.';
 
         if (error.code === 404) {
             message = 'Could not find your Google Sheets document. Please ensure SHEETS_DOC_ID is correct.';
         }
         else if (error.code === 400 && error.errors && error.errors[0] && error.errors[0].message) {
-            message = `Google sheets error: ${error.errors[0].message}. Please ensure SHEETS_SHEET_NAME is a valid spreadsheet inside your document.`;
+            console.error(`Google sheets error: ${error.errors[0].message}. Please ensure SHEETS_SHEET_NAME is a valid spreadsheet inside your document.`);
+        }
+        else {
+            console.error(`Google Sheets integration error: ${error.message || error}`);
         }
 
         response.setStatusCode(error.code || 400);

--- a/google-sheets/functions/log-sms.js
+++ b/google-sheets/functions/log-sms.js
@@ -17,7 +17,7 @@ exports.handler = async function(context, event, callback) {
       auth,
     });
 
-    const res = await sheets.spreadsheets.values.append({
+    await sheets.spreadsheets.values.append({
       spreadsheetId: context.SHEETS_DOC_ID,
       range: `'${context.SHEETS_SHEET_NAME}'`,
       valueInputOption: 'USER_ENTERED',

--- a/google-sheets/functions/log-sms.js
+++ b/google-sheets/functions/log-sms.js
@@ -1,0 +1,32 @@
+const { google } = require('googleapis');
+
+exports.handler = async function(context, event, callback) {
+  const auth = new google.auth.GoogleAuth({
+    keyFile: context.SHEETS_SERVICE_ACCOUNT_JSON,
+    scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+  });
+  const twiml = new Twilio.twiml.MessagingResponse();
+
+  try {
+    const sheets = google.sheets({
+      version: 'v4',
+      auth,
+    });
+
+    const res = await sheets.spreadsheets.values.append({
+      spreadsheetId: context.SHEETS_DOC_ID,
+      range: `'${context.SHEETS_SHEET_NAME}'`,
+      valueInputOption: 'USER_ENTERED',
+      requestBody: {
+        values: [
+          [event.SmsSid, event.From, event.Body]
+        ],
+      }});
+
+    twiml.message('The SMS was successfully saved.');
+    callback(null, twiml);
+  } catch (error) {
+    console.log({ error });
+    callback(error);
+  }
+};

--- a/google-sheets/functions/log-sms.protected.js
+++ b/google-sheets/functions/log-sms.protected.js
@@ -1,10 +1,9 @@
 const { google } = require('googleapis');
-const path = require('path');
 
 exports.handler = async function(context, event, callback) {
   // Assemble an authentication JWT from a service account email and private
   // key provided as environment variables:
-  const authJson = require(path.join('..', context.SHEETS_AUTH_JSON));
+  const authJson = require(Runtime.getAssets()[context.SHEETS_AUTH_JSON].path);
   const auth = new google.auth.JWT({
     email: authJson.client_email,
     key: authJson.private_key,

--- a/google-sheets/functions/log-sms.protected.js
+++ b/google-sheets/functions/log-sms.protected.js
@@ -1,17 +1,17 @@
 const { google } = require('googleapis');
+const fs = require('fs').promises;
 
 exports.handler = async function(context, event, callback) {
-  // Assemble an authentication JWT from a service account email and private
-  // key provided as environment variables:
-  const authJson = require(Runtime.getAssets()[context.SHEETS_AUTH_JSON].path);
-  const auth = new google.auth.JWT({
-    email: authJson.client_email,
-    key: authJson.private_key,
-    scopes: [ 'https://www.googleapis.com/auth/spreadsheets' ],
-  });
   const twiml = new Twilio.twiml.MessagingResponse();
-
   try {
+    const authJson = JSON.parse(await fs.readFile(
+      Runtime.getAssets()[context.SHEETS_AUTH_JSON].path));
+    const auth = new google.auth.JWT({
+      email: authJson.client_email,
+      key: authJson.private_key,
+      scopes: [ 'https://www.googleapis.com/auth/spreadsheets' ],
+    });
+
     const sheets = google.sheets({
       version: 'v4',
       auth,

--- a/google-sheets/package.json
+++ b/google-sheets/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "google-sheets",
+  "dependencies": {
+    "googleapis": "^65.0.0"
+  }
+}

--- a/google-sheets/tests/auth.test.json
+++ b/google-sheets/tests/auth.test.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "test project ID",
+  "private_key_id": "test private key ID",
+  "private_key": "test private key",
+  "client_email": "test@example.org",
+  "client_id": "test client ID",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://example.org/test"
+}

--- a/google-sheets/tests/check-sheets-config.test.js
+++ b/google-sheets/tests/check-sheets-config.test.js
@@ -16,13 +16,15 @@ google.sheets.mockReturnValue({
 });
 
 const context = {
-  SHEETS_AUTH_JSON: '/assets/auth.private.json',
+  SHEETS_AUTH_JSON: '/auth.json',
   SHEETS_DOC_ID: 'appAbcD12efG3HijK',
   SHEETS_SHEET_NAME: 'Sheet1',
 };
 
 beforeAll(() => {
-  helpers.setup(context);
+  const runtime = new helpers.MockRuntime();
+  runtime._addAsset('/auth.json', './auth.test.json');
+  helpers.setup(context, runtime);
 });
 
 afterAll(() => {

--- a/google-sheets/tests/check-sheets-config.test.js
+++ b/google-sheets/tests/check-sheets-config.test.js
@@ -57,7 +57,6 @@ it('should handle Google Sheets API errors', done => {
 
   const callback = (_err, res) => {
     expect(res._body.success).toBeFalsy();
-    expect(res._body.message).toEqual(`Google Sheets integration error: ${errorMessage}`);
     done();
   };
 
@@ -84,7 +83,7 @@ it('should handle a missing Google Sheets document', done => {
   checkConfig(context, event, callback);
 });
 
-it('should pass along Google Sheets API errors', done => {
+it('should log Google Sheets API errors', done => {
   const testError = 'API test error';
   google.sheets.mockReturnValueOnce({
     spreadsheets: {
@@ -99,7 +98,6 @@ it('should pass along Google Sheets API errors', done => {
 
   const callback = (_err, res) => {
     expect(res._body.success).toBeFalsy();
-    expect(res._body.message).toEqual(`Google sheets error: ${testError}. Please ensure SHEETS_SHEET_NAME is a valid spreadsheet inside your document.`);
     done();
   };
 

--- a/google-sheets/tests/check-sheets-config.test.js
+++ b/google-sheets/tests/check-sheets-config.test.js
@@ -1,0 +1,106 @@
+const helpers = require('../../test/test-helper');
+const checkConfig = require('../functions/check-sheets-config').handler;
+const { google } = require('googleapis');
+
+const event = {};
+
+jest.mock('googleapis');
+
+google.auth.JWT.mockReturnValue();
+google.sheets.mockReturnValue({
+  spreadsheets: {
+    values: {
+      get: jest.fn(() => Promise.resolve())
+    },
+  },
+});
+
+const context = {
+  SHEETS_CLIENT_EMAIL: 'test@example.com',
+  SHEETS_PRIVATE_KEY: '1234testkey',
+  SHEETS_DOC_ID: 'appAbcD12efG3HijK',
+  SHEETS_SHEET_NAME: 'Sheet1',
+};
+
+beforeAll(() => {
+  helpers.setup(context);
+});
+
+afterAll(() => {
+  helpers.teardown();
+});
+
+it('should return a success message for a valid configuration', done => {
+  const callback = (err, res) => {
+    expect(err).toBeFalsy();
+    expect(res._body.success).toBeTruthy();
+    expect(res._body.message).toMatch('Google Sheets integration is configured properly.');
+    done();
+  };
+
+  checkConfig(context, event, callback);
+});
+
+it('should handle Google Sheets API errors', done => {
+  const errorMessage = 'generic test error';
+  google.sheets.mockReturnValueOnce({
+    spreadsheets: {
+      values: {
+        get: jest.fn(() => Promise.reject({
+          code: 401,
+          message: errorMessage,
+        }))
+      },
+    },
+  });
+
+  const callback = (_err, res) => {
+    expect(res._body.success).toBeFalsy();
+    expect(res._body.message).toEqual(`Google Sheets integration error: ${errorMessage}`);
+    done();
+  };
+
+  checkConfig(context, event, callback);
+});
+
+it('should handle a missing Google Sheets document', done => {
+  google.sheets.mockReturnValueOnce({
+    spreadsheets: {
+      values: {
+        get: jest.fn(() => Promise.reject({
+          code: 404,
+        }))
+      },
+    },
+  });
+
+  const callback = (_err, res) => {
+    expect(res._body.success).toBeFalsy();
+    expect(res._body.message).toEqual('Could not find your Google Sheets document. Please ensure SHEETS_DOC_ID is correct.');
+    done();
+  };
+
+  checkConfig(context, event, callback);
+});
+
+it('should pass along Google Sheets API errors', done => {
+  const testError = 'API test error';
+  google.sheets.mockReturnValueOnce({
+    spreadsheets: {
+      values: {
+        get: jest.fn(() => Promise.reject({
+          code: 400,
+          errors: [{ message: testError }],
+        }))
+      },
+    },
+  });
+
+  const callback = (_err, res) => {
+    expect(res._body.success).toBeFalsy();
+    expect(res._body.message).toEqual(`Google sheets error: ${testError}. Please ensure SHEETS_SHEET_NAME is a valid spreadsheet inside your document.`);
+    done();
+  };
+
+  checkConfig(context, event, callback);
+});

--- a/google-sheets/tests/check-sheets-config.test.js
+++ b/google-sheets/tests/check-sheets-config.test.js
@@ -16,8 +16,7 @@ google.sheets.mockReturnValue({
 });
 
 const context = {
-  SHEETS_CLIENT_EMAIL: 'test@example.com',
-  SHEETS_PRIVATE_KEY: '1234testkey',
+  SHEETS_AUTH_JSON: '/assets/auth.private.json',
   SHEETS_DOC_ID: 'appAbcD12efG3HijK',
   SHEETS_SHEET_NAME: 'Sheet1',
 };

--- a/google-sheets/tests/log-sms.test.js
+++ b/google-sheets/tests/log-sms.test.js
@@ -16,13 +16,15 @@ google.sheets.mockReturnValue({
 });
 
 const context = {
-  SHEETS_AUTH_JSON: '/assets/auth.private.json',
+  SHEETS_AUTH_JSON: '/auth.json',
   SHEETS_DOC_ID: 'appAbcD12efG3HijK',
   SHEETS_SHEET_NAME: 'Sheet1',
 };
 
 beforeAll(() => {
-  helpers.setup(context);
+  const runtime = new helpers.MockRuntime();
+  runtime._addAsset('/auth.json', './auth.test.json');
+  helpers.setup(context, runtime);
 });
 
 afterAll(() => {

--- a/google-sheets/tests/log-sms.test.js
+++ b/google-sheets/tests/log-sms.test.js
@@ -4,25 +4,10 @@ const Twilio = require('twilio');
 
 const event = {};
 
-const mockGoogleClient = {
-  google: {
-    auth: {
-      GoogleAuth: jest.fn(),
-    },
-    sheets: jest.fn(() => ({
-      spreadsheets: {
-        values: {
-          append: jest.fn(() => Promise.resolve())
-        },
-      },
-    })),
-  }
-};
-
 jest.mock('googleapis', () => ({
   google: {
     auth: {
-      GoogleAuth: jest.fn(),
+      JWT: jest.fn(),
     },
     sheets: jest.fn(() => ({
       spreadsheets: {
@@ -35,9 +20,10 @@ jest.mock('googleapis', () => ({
 }));
 
 const context = {
+  SHEETS_CLIENT_EMAIL: 'test@example.com',
+  SHEETS_PRIVATE_KEY: '1234testkey',
   SHEETS_DOC_ID: 'appAbcD12efG3HijK',
   SHEETS_SHEET_NAME: 'Sheet1',
-  SHEETS_SERVICE_ACCOUNT_JSON: './assets/auth.json',
 };
 
 beforeAll(() => {

--- a/google-sheets/tests/log-sms.test.js
+++ b/google-sheets/tests/log-sms.test.js
@@ -1,0 +1,67 @@
+const helpers = require('../../test/test-helper');
+const logSms = require('../functions/log-sms').handler;
+const Twilio = require('twilio');
+
+const event = {};
+
+const mockGoogleClient = {
+  google: {
+    auth: {
+      GoogleAuth: jest.fn(),
+    },
+    sheets: jest.fn(() => ({
+      spreadsheets: {
+        values: {
+          append: jest.fn(() => Promise.resolve())
+        },
+      },
+    })),
+  }
+};
+
+jest.mock('googleapis', () => ({
+  google: {
+    auth: {
+      GoogleAuth: jest.fn(),
+    },
+    sheets: jest.fn(() => ({
+      spreadsheets: {
+        values: {
+          append: jest.fn(() => Promise.resolve())
+        },
+      },
+    })),
+  }
+}));
+
+const context = {
+  SHEETS_DOC_ID: 'appAbcD12efG3HijK',
+  SHEETS_SHEET_NAME: 'Sheet1',
+  SHEETS_SERVICE_ACCOUNT_JSON: './assets/auth.json',
+};
+
+beforeAll(() => {
+  helpers.setup(context);
+});
+
+afterAll(() => {
+  helpers.teardown();
+});
+
+test('returns a MessageResponse', done => {
+  const callback = (err, result) => {
+    expect(result).toBeInstanceOf(Twilio.twiml.MessagingResponse);
+    done();
+  };
+
+  logSms(context, event, callback);
+});
+
+test('successfully saved the message', done => {
+  const callback = (err, result) => {
+    expect(result.toString()).toMatch('<Message>The SMS was successfully saved.</Message>');
+    done();
+  };
+
+  logSms(context, event, callback);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8868,6 +8868,15 @@
       "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "acorn": {
       "version": "5.7.4",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
@@ -9245,6 +9254,12 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -9253,6 +9268,12 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -10675,6 +10696,12 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true
+    },
     "exec-sh": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
@@ -10898,6 +10925,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fast-text-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==",
       "dev": true
     },
     "fb-watchman": {
@@ -11641,6 +11674,71 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "gaxios": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.0.1.tgz",
+      "integrity": "sha512-jOin8xRZ/UytQeBpSXFqIzqU7Fi5TqgPNLlUsSB8kjJ76+FiGBfImF8KJu++c6J4jOldfJUtt0YmkRj2ZpSHTQ==",
+      "dev": true,
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.3.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "dev": true,
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "gcp-metadata": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
+      "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
+      "dev": true,
+      "requires": {
+        "gaxios": "^4.0.0",
+        "json-bigint": "^1.0.0"
+      }
+    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -11725,11 +11823,119 @@
         "pinkie-promise": "^2.0.0"
       }
     },
+    "google-auth-library": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.3.tgz",
+      "integrity": "sha512-m9mwvY3GWbr7ZYEbl61isWmk+fvTmOt0YNUfPOUY2VH8K5pZlAIWJjxEi0PqR3OjMretyiQLI6GURMrPSwHQ2g==",
+      "dev": true,
+      "requires": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+          "dev": true
+        },
+        "jwa": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+          "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+          "dev": true,
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+          "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+          "dev": true,
+          "requires": {
+            "jwa": "^2.0.0",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "google-libphonenumber": {
       "version": "3.2.10",
       "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.10.tgz",
       "integrity": "sha512-TsckE9O8QgqaIeaOXPjcJa4/kX3BzFdO1oCbMfmUpRZckml4xJhjJVxaT9Mdt/VrZZkT9lX44eHAEWfJK1tHtw==",
       "dev": true
+    },
+    "google-p12-pem": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
+      "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
+      "dev": true,
+      "requires": {
+        "node-forge": "^0.10.0"
+      }
+    },
+    "googleapis": {
+      "version": "65.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-65.0.0.tgz",
+      "integrity": "sha512-dcfZVkML8H6mPAsph0hgfyRQYKJpw2XjKchAXx5YEfDYWU7021Mpzaf+ejNSipa3QmcfOLOcWg6sUr0I7M4jjQ==",
+      "dev": true,
+      "requires": {
+        "google-auth-library": "^6.0.0",
+        "googleapis-common": "^4.4.1"
+      }
+    },
+    "googleapis-common": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-4.4.3.tgz",
+      "integrity": "sha512-W46WKCk3QtlCCfmZyQIH5zxmDOyeV5Qj+qs7nr2ox08eRkEJMWp6iwv542R/PsokXaGUSrmif4vCC4+rGzRSsQ==",
+      "dev": true,
+      "requires": {
+        "extend": "^3.0.2",
+        "gaxios": "^4.0.0",
+        "google-auth-library": "^6.0.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.9.4",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+          "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "8.3.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
+          "dev": true
+        }
+      }
     },
     "got": {
       "version": "6.7.1",
@@ -11760,6 +11966,41 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
+    },
+    "gtoken": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.1.0.tgz",
+      "integrity": "sha512-4d8N6Lk8TEAHl9vVoRVMh9BNOKWVgl2DdNtr3428O75r3QFrF/a5MMu851VmK0AA8+iSvbwRv69k5XnMLURGhg==",
+      "dev": true,
+      "requires": {
+        "gaxios": "^4.0.0",
+        "google-p12-pem": "^3.0.3",
+        "jws": "^4.0.0",
+        "mime": "^2.2.0"
+      },
+      "dependencies": {
+        "jwa": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+          "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+          "dev": true,
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+          "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+          "dev": true,
+          "requires": {
+            "jwa": "^2.0.0",
+            "safe-buffer": "^5.0.1"
+          }
+        }
+      }
     },
     "handlebars": {
       "version": "4.7.6",
@@ -13132,6 +13373,15 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -13786,6 +14036,12 @@
         "to-regex": "^3.0.2"
       }
     },
+    "mime": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+      "dev": true
+    },
     "mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
@@ -13933,6 +14189,12 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
+    "node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-int64": {
@@ -15948,6 +16210,12 @@
       "requires": {
         "prepend-http": "^1.0.1"
       }
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+      "dev": true
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "configure-env": "^2.0.0-0",
     "copy-template-dir": "^1.4.0",
     "eslint": "^5.4.0",
+    "googleapis": "^65.0.0",
     "husky": "^4.2.5",
     "inquirer": "^7.0.4",
     "jest-cli": "^24.8.0",

--- a/templates.json
+++ b/templates.json
@@ -244,6 +244,11 @@
       "id": "segment-event-notification",
       "name": "Segment Track Notification",
       "description": "Sends an SMS when your Segment-enabled website generates a specific tracking event."
+    },
+    {
+      "id": "google-sheets",
+      "name": "Google Sheets SMS Log",
+      "description": "Logs incoming SMS numbers and messages into a Google Sheets table"
     }
   ]
 }


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description
Adds the google-sheets template, which logs incoming SMS numbers and text bodies to a Google Sheets spreadsheet.

This is a candidate for a Quick Deploy function, but there are a couple of setup complexities instituted by Google's API:
- The user must create a Google Cloud service account, generate a private key file for it, and add that file to the function's assets. The service account is a strict requirement of how Google handles OAuth permissions. There may be an undocumented way to pull authentication information from an environment variable instead of a file, but this may not be a stable part of Google's API.
- The spreadsheet being logged into is created by the user (which saves a lot of document management complexity for this code example) and then shared with the service account's email address.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
