### PR TITLE
docs: Fixing a little formatting nit

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -128,7 +128,7 @@ If you want to test how your new template works with the Twilio CLI, make sure y
 
 Afterwards make sure you push your changes to a different branch or fork of the repository. Your changes have to be uploaded to GitHub for you to be able to test them.
 
-For example if I'm working on the `verify` template, I might push my changes to a new branch called `update-verify` under my personal fork of the `function-templates` repository, located at: https://github.com/**dkundel/function-templates**.
+For example if I'm working on the `verify` template, I might push my changes to a new branch called `update-verify` under my personal fork of the `function-templates` repository, located at: https://github.com/dkundel/function-templates.
 
 In order to test if my changes are working, I can invoke the `twilio serverless:init` command with the following flags:
 


### PR DESCRIPTION
## Description

This fixes a small formatting error in CONTRIBUTING.md.

Using `**bold**` to hightlight a part of a URL doesn't work in GH-flavored markdown, apparently.

## Checklist

- [X] I ran `npm test` locally and it passed without errors.
- [X] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).
