### PR TITLE
feat(templates): Create a Zapier integration function template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13934,6 +13934,12 @@
       "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "log-symbols": "^3.0.0",
     "mailgun-js": "0.22.0",
     "moment": "^2.24.0",
+    "node-fetch": "^2.6.1",
     "stripe": "^8.20.0",
     "twilio": "^3.43.0"
   },

--- a/templates.json
+++ b/templates.json
@@ -214,6 +214,11 @@
       "id": "forward-message-mailgun",
       "name": "Forward SMS message as an email (Mailgun)",
       "description": "The function will forward incoming SMS messages to an email address using the Mailgun API"
+    },
+    {
+      "id": "zapier",
+      "name": "Zapier Webhook",
+      "description": "Push incoming SMS metadata and contents to a Zapier webhook"
     }
   ]
 }

--- a/zapier/.env
+++ b/zapier/.env
@@ -1,0 +1,4 @@
+# description: The URL for your Zapier Catch Hook webhook trigger
+# format: text
+# required: true
+ZAPIER_WEBHOOK_URL=

--- a/zapier/README.md
+++ b/zapier/README.md
@@ -1,0 +1,54 @@
+# Zapier
+
+Push incoming SMS metadata and contents to a Zapier webhook.
+
+## Pre-requisites
+
+To push data to Zapier, you will need a [Zapier](https://zapier.com) account and
+a Zap with a [Catch Hook webhook trigger](https://zapier.com/help/create/code-webhooks/trigger-zaps-from-webhooks).
+
+### Environment variables
+
+This project requires some environment variables to be set. To keep your tokens and secrets secure, make sure to not commit the `.env` file in git. When setting up the project with `twilio serverless:init ...` the Twilio CLI will create a `.gitignore` file that excludes `.env` from the version history.
+
+In your `.env` file, set the following values:
+
+| Variable           | Description                                       | Required |
+| :----------------- | :------------------------------------------------ | :------- |
+| ZAPIER_WEBHOOK_URL | The URL for your Zap's Catch Hook webhook trigger | Yes      |
+
+## Create a new project with the template
+
+1. Install the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart#install-twilio-cli)
+2. Install the [serverless toolkit](https://www.twilio.com/docs/labs/serverless-toolkit/getting-started)
+
+```shell
+twilio plugins:install @twilio-labs/plugin-serverless
+```
+
+3. Initiate a new project
+
+```
+twilio serverless:init example --template=zapier && cd example
+```
+
+4. Start the server with the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart):
+
+```
+twilio serverless:start
+```
+
+5. Open the web page at https://localhost:3000/index.html and follow the
+   instructions to test your application.
+
+ℹ️ Check the developer console and terminal for any errors, make sure you've set your environment variables.
+
+## Deploying
+
+Deploy your functions and assets with either of the following commands. Note: you must run these commands from inside your project folder. [More details in the docs.](https://www.twilio.com/docs/labs/serverless-toolkit)
+
+With the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart):
+
+```
+twilio serverless:deploy
+```

--- a/zapier/assets/index.html
+++ b/zapier/assets/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Get started with your Twilio Functions!</title>
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
+    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
+    <style>
+      body {
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+      }
+
+      div[role="main"] {
+        flex: 1;
+      }
+
+      footer {
+        text-align: center;
+      }
+
+      footer p {
+        margin-bottom: 0;
+      }
+
+      #twilio-logo {
+        width: 50px;
+        height: 50px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Welcome to your new Twilio App</h1>
+    </header>
+    <div role="main">
+      <section>
+        <h3>Get started with your app</h3>
+        <p>This app exposes the metadata and contents of the SMS messages received by your phone number to a Zapier webhook trigger. Follow the steps below to test your app:</p>
+        <ol>
+          <li>Text your Twilio phone number with a message.</li>
+          <li>You should see your Zapier webhook trigger receive the JSON data for the text you sent.</li>
+        </ol>
+      </section>
+      <section>
+        <h3>Troubleshooting</h3>
+        <ul>
+          <li>Check the <a href="https://www.twilio.com/console/phone-numbers/incoming">phone number configuration</a> and make sure the Twilio phone number you want your app has an SMS webhook configured to point at
+            <p>
+              <pre><code><span class="function-root"></span>/sms-to-webhook</code></pre>
+            </p>
+          </li>
+          <li>Ensure that you have a Zapier Catch Hook webhook configured, and that you have provided its URL as the <code>ZAPIER_WEBHOOK_URL</code> environment variable for this function.</li>
+        </ul>
+      </section>
+    </div>
+    <footer>
+      <p>
+        <a href="https://www.twilio.com/">
+          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+            <defs>
+              <style>
+                .cls-1 {
+                  fill: #f22f46;
+                }
+              </style>
+            </defs>
+            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+        </a>
+      </p>
+      <p>
+        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
+      </p>
+    </footer>
+
+    <script>
+      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
+      const baseUrl = new URL(location.href);
+      baseUrl.pathname = baseUrl
+        .pathname
+        .replace(/\/index\.html$/, '');
+      delete baseUrl.hash;
+      delete baseUrl.search;
+      const fullUrl = baseUrl
+        .href
+        .substr(0, baseUrl.href.length - 1);
+      const functionRoots = document.querySelectorAll('span.function-root');
+
+      functionRoots.forEach(element => {
+        element.innerText = fullUrl
+      })
+    </script>
+  </body>
+</html>

--- a/zapier/functions/sms-to-webhook.js
+++ b/zapier/functions/sms-to-webhook.js
@@ -1,0 +1,24 @@
+const fetch = require('node-fetch');
+
+exports.handler = async function(context, event, callback) {
+  try {
+    const res = await fetch(context.ZAPIER_WEBHOOK_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(event),
+    });
+
+    if (res.ok) {
+      callback(null, {});
+    }
+    else {
+      console.log(res.statusText);
+      callback(res.statusText)
+    }
+  } catch (error) {
+    console.log({ error });
+    callback(error);
+  }
+};

--- a/zapier/package.json
+++ b/zapier/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "zapier",
+  "dependencies": {
+    "node-fetch": "^2.6.1"
+  }
+}

--- a/zapier/tests/sms-to-webhook.test.js
+++ b/zapier/tests/sms-to-webhook.test.js
@@ -1,0 +1,38 @@
+const helpers = require('../../test/test-helper');
+const smsToWebhook = require('../functions/sms-to-webhook').handler;
+
+const context = {
+    ZAPIER_WEBHOOK_URL: 'http://example.com/webhook,'
+};
+
+const mockFetchResponse = {
+    ok: true,
+};
+
+jest.mock('node-fetch', () => {
+    return jest.fn().mockImplementation(() => {
+        return mockFetchResponse;
+    });
+});
+
+beforeAll(() => {
+  helpers.setup(context);
+});
+
+afterAll(() => {
+  helpers.teardown();
+});
+
+it('should successfully call its webhook', (done) => {
+    const callback = (err, _result) => {
+        expect(err).toBeFalsy();
+        done();
+    };
+
+    const event = {
+        Body: 'Hello world',
+        From: 'ExternalNumber',
+    };
+
+    smsToWebhook(context, event, callback);
+});


### PR DESCRIPTION
## Description
The `zapier` function template receives an SMS (or potentially another event) and pushes its JSON body to Zapier for use in a Zap workflow.

Since this is a very simple adapter function, it should be trivial to adapt this code to other Twilio events. It should also be possible to hook a Twilio phone number up to a Zapier Catch Hook directly, but this Quick Deployable function template provides a level of documentation via Code Exchange, as well as an insertion point for code integrating other Twilio services into Zapier. This integration requires the Zapier Webhooks premium feature.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
