### PR TITLE
fest(testing): Add a Jest test for missing template .env files

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -74,6 +74,8 @@ MY_PHONE_NUMBER=
 
 They should also be mentioned in the existing table inside the `README.md` of your template directory.
 
+**Note**: All function templates are checked for the presence of a `.env` file by `npm test`. If a test named `should have a .env file` fails, ensure that your function template's `.env` file exists and `git add` has been used to add it to your commit. If your function template lacks environment variables, commit an empty `.env` file. If the test is failing due to a directory that is not a function template, add that directory to the `excludedPaths` variable in `test/all-templates.test.js`.
+
 ### Updating the `index.html`
 
 If your app has a front-end component to it, you can override the existing `index.html` file in your project.

--- a/test/all-templates.test.js
+++ b/test/all-templates.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+// This file contains Jest tests that run against every function template in
+// the repo.
+
+const path = require('path');
+const fs = require('fs');
+
+const excludedPaths = ['node_modules', 'test', 'coverage', 'docs'];
+const projectRoot = path.resolve(__dirname, '..');
+// Assemble a list of template directories here, since templates.json
+// may not have all of them:
+const templates = fs
+      .readdirSync(projectRoot, { withFileTypes: true })
+      .filter(
+        (file) =>
+        file.isDirectory() &&
+          !file.name.startsWith('.') &&
+          !file.name.startsWith('_') &&
+          !excludedPaths.includes(file.name)
+      )
+      .map((dir) => dir.name);
+
+describe.each(templates)('the "%s" function template', (template) => {
+    it('should have a .env file', (done) => {
+        const envFile = path.join(projectRoot, template, '.env');
+        fs.access(envFile, fs.constants.F_OK, (err) => {
+            expect(err).toBeFalsy();
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## Description
Adds a new Jest test that runs against each function template and ensures that each one has a `.env` file, to prevent deployment errors caused by the file being missing. This test will run both locally and on the CI to catch cases where `.env` exists locally, but is accidentally not committed.

The new test lives in test/all-templates.test.js, which uses FileHound to collect a list of repo subdirectories with a package.json, and generates Jest tests for each one. An individual test was created per `.env` file because it had a minimal impact on `npm test` performance (on the order of a 0.15 second runtime increase from a hot cache), but allowed for much more expressive failed assertion messages in case of a failed test.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
