### PR TITLE
feat(templates): create masked-number template

### DIFF
--- a/masked-number/.env
+++ b/masked-number/.env
@@ -1,0 +1,8 @@
+# description: The number you want to forward incoming messages to
+# format: phone_number
+# required: true
+MY_PHONE_NUMBER=+1112223333
+
+# description: The path to the webhook
+# configurable: false
+TWILIO_SMS_WEBHOOK_URL=/relay-sms

--- a/masked-number/README.md
+++ b/masked-number/README.md
@@ -1,6 +1,6 @@
-# masked-number
+# Masked Number
 
-Uses a Twilio phone number to relay SMS messages to and from your phone.
+Uses a Twilio phone number to relay SMS messages to and from your phone; since the other party only sees your Twilio number, this effectively allows you to mask your phone number for privacy purposes.
 
 ## Pre-requisites
 

--- a/masked-number/README.md
+++ b/masked-number/README.md
@@ -1,0 +1,50 @@
+# masked-number
+
+Uses a Twilio phone number to relay SMS messages to and from your phone.
+
+## Pre-requisites
+
+### Environment variables
+
+This project requires some environment variables to be set. To keep your tokens and secrets secure, make sure to not commit the `.env` file in git. When setting up the project with `twilio serverless:init ...` the Twilio CLI will create a `.gitignore` file that excludes `.env` from the version history.
+
+In your `.env` file, set the following values:
+
+| Variable        | Description                                        | Required |
+| :-------------- | :------------------------------------------------- | :------- |
+| MY_PHONE_NUMBER | The phone number which SMS messages get relayed to | Yes      |
+
+## Create a new project with the template
+
+1. Install the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart#install-twilio-cli)
+2. Install the [serverless toolkit](https://www.twilio.com/docs/labs/serverless-toolkit/getting-started)
+
+```shell
+twilio plugins:install @twilio-labs/plugin-serverless
+```
+
+3. Initiate a new project
+
+```
+twilio serverless:init example --template=masked-number && cd example
+```
+
+4. Start the server with the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart):
+
+```
+twilio serverless:start
+```
+
+5. Open the web page at https://localhost:3000/index.html and enter your phone number to test
+
+ℹ️ Check the developer console and terminal for any errors, make sure you've set your environment variables.
+
+## Deploying
+
+Deploy your functions and assets with either of the following commands. Note: you must run these commands from inside your project folder. [More details in the docs.](https://www.twilio.com/docs/labs/serverless-toolkit)
+
+With the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart):
+
+```
+twilio serverless:deploy
+```

--- a/masked-number/assets/index.html
+++ b/masked-number/assets/index.html
@@ -42,9 +42,9 @@
         <h3>Get started with your app</h3>
         <p>This app masks your phone number for SMS messages by relaying them through a Twilio phone number. Follow the steps below to test your app:</p>
         <ol>
-          <li>Text your Twilio phone number with a recipient phone number, a <code>:</code>, and a message.</li>
+          <li>Text your Twilio phone number with a recipient phone number, a <code>:</code>, and a message. For example, to send the message "hello" to the number "+12223334444", text your Twilio phone number with: <code>+12223334444: hello</code>.</li>
           <li>Your recipient should receive your message from your Twilio phone number.</li>
-          <li>Give your Twilio phone number to another person when you want to message them without exposing your personal phone number.</li>
+          <li>When that recipient sends a reply to your Twilio phone number, it will be relayed to your personal phone number.</li>
         </ol>
       </section>
       <section>
@@ -58,6 +58,7 @@
           <li>Ensure that <code>MY_PHONE_NUMBER</code> is set to the phone number you want to relay messages to, in <a href="https://www.twilio.com/docs/glossary/what-e164">E.164 format</a>.</li>
         </ul>
       </section>
+      <!-- APP_INFO -->
     </div>
     <footer>
       <p>

--- a/masked-number/assets/index.html
+++ b/masked-number/assets/index.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Get started with your Twilio Functions!</title>
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
+    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
+    <style>
+      body {
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+      }
+
+      div[role="main"] {
+        flex: 1;
+      }
+
+      footer {
+        text-align: center;
+      }
+
+      footer p {
+        margin-bottom: 0;
+      }
+
+      #twilio-logo {
+        width: 50px;
+        height: 50px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Welcome to your new Twilio App</h1>
+    </header>
+    <div role="main">
+      <section>
+        <h3>Get started with your app</h3>
+        <p>This app masks your phone number for SMS messages by relaying them through a Twilio phone number. Follow the steps below to test your app:</p>
+        <ol>
+          <li>Text your Twilio phone number with a recipient phone number, a <code>:</code>, and a message.</li>
+          <li>Your recipient should receive your message from your Twilio phone number.</li>
+          <li>Give your Twilio phone number to another person when you want to message them without exposing your personal phone number.</li>
+        </ol>
+      </section>
+      <section>
+        <h3>Troubleshooting</h3>
+        <ul>
+          <li>Check the <a href="https://www.twilio.com/console/phone-numbers/incoming">phone number configuration</a> and make sure the Twilio phone number you want your app has an SMS webhook configured to point at
+            <p>
+              <pre><code><span class="function-root"></span>/relay-sms</code></pre>
+            </p>
+          </li>
+          <li>Ensure that <code>MY_PHONE_NUMBER</code> is set to the phone number you want to relay messages to, in <a href="https://www.twilio.com/docs/glossary/what-e164">E.164 format</a>.</li>
+        </ul>
+      </section>
+    </div>
+    <footer>
+      <p>
+        <a href="https://www.twilio.com/">
+          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+            <defs>
+              <style>
+                .cls-1 {
+                  fill: #f22f46;
+                }
+              </style>
+            </defs>
+            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+        </a>
+      </p>
+      <p>
+        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
+      </p>
+    </footer>
+
+    <script>
+      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
+      const baseUrl = new URL(location.href);
+      baseUrl.pathname = baseUrl
+        .pathname
+        .replace(/\/index\.html$/, '');
+      delete baseUrl.hash;
+      delete baseUrl.search;
+      const fullUrl = baseUrl
+        .href
+        .substr(0, baseUrl.href.length - 1);
+      const functionRoots = document.querySelectorAll('span.function-root');
+
+      functionRoots.forEach(element => {
+        element.innerText = fullUrl
+      })
+    </script>
+  </body>
+</html>

--- a/masked-number/functions/relay-sms.protected.js
+++ b/masked-number/functions/relay-sms.protected.js
@@ -6,7 +6,7 @@ exports.handler = async function(context, event, callback) {
     const separatorPosition = event.Body.indexOf(':');
 
     if (separatorPosition < 1) {
-      twiml.message('You need to specify a recipient number and a ":" before the message.');
+      twiml.message('You need to specify a recipient number and a ":" before the message. For example, "+12223334444: message".');
     } else {
       const recipientNumber = event.Body.substr(0, separatorPosition).trim();
       const messageBody = event.Body.substr(separatorPosition + 1).trim();
@@ -22,7 +22,7 @@ exports.handler = async function(context, event, callback) {
         return callback(null);
       }
       catch (err) {
-        twiml.message("I couldn't understand the recipient phone number you entered.");
+        twiml.message("There was an issue with the phone number you entered; please verify it is correct and try again.");
       }
     }
   } else {

--- a/masked-number/functions/relay-sms.protected.js
+++ b/masked-number/functions/relay-sms.protected.js
@@ -1,0 +1,33 @@
+exports.handler = async function(context, event, callback) {
+  const client = context.getTwilioClient();
+  const twiml = new Twilio.twiml.MessagingResponse();
+
+  if (event.From === context.MY_PHONE_NUMBER) {
+    const separatorPosition = event.Body.indexOf(':');
+
+    if (separatorPosition < 1) {
+      twiml.message('You need to specify a recipient number and a ":" before the message.');
+    } else {
+      const recipientNumber = event.Body.substr(0, separatorPosition).trim();
+      const messageBody = event.Body.substr(separatorPosition + 1).trim();
+
+      try {
+        await client.messages
+                    .create({
+                      to: recipientNumber,
+                      from: event.To,
+                      body: messageBody
+                    });
+
+        return callback(null);
+      }
+      catch (err) {
+        twiml.message("I couldn't understand the recipient phone number you entered.");
+      }
+    }
+  } else {
+    twiml.message({ to: context.MY_PHONE_NUMBER }, `${event.From}: ${event.Body}`);
+  }
+
+  callback(null, twiml);
+};

--- a/masked-number/package.json
+++ b/masked-number/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "masked-number",
+  "dependencies": {}
+}

--- a/masked-number/tests/relay-sms.test.js
+++ b/masked-number/tests/relay-sms.test.js
@@ -1,0 +1,106 @@
+const relaySms = require('../functions/relay-sms.protected').handler;
+const helpers = require('../../test/test-helper');
+
+let shouldFail = false;
+const mockTwilioClient = {
+  messages: {
+    create: jest.fn(() => {
+      if (shouldFail) {
+        return Promise.reject('Expected test error');
+      }
+
+      return Promise.resolve({
+        sid: 'my-new-sid',
+      });
+    }),
+  },
+};
+
+const context = {
+  getTwilioClient: () => mockTwilioClient,
+  MY_PHONE_NUMBER: '+1112223333',
+};
+
+const baseEvent = {
+  From: context.MY_PHONE_NUMBER,
+  To: '+13334445555',
+  Body: '+16667778888: test message',
+};
+
+beforeAll(() => {
+  helpers.setup(context);
+});
+
+afterAll(() => {
+  helpers.teardown();
+});
+
+beforeEach(() => {
+  shouldFail = false;
+  mockTwilioClient.messages.create.mockClear();
+});
+
+describe('masked-number function template', () => {
+  it('should send a message to a given phone number', (done) => {
+    const event = { ...baseEvent };
+    const callback = (err, _result) => {
+      expect(err).toBeFalsy();
+      expect(mockTwilioClient.messages.create).toHaveBeenCalled();
+
+      done();
+    }
+
+    relaySms(context, event, callback);
+  });
+
+  it('should relay messages from other phone numbers', (done) => {
+    const event = { ...baseEvent,
+                    From: baseEvent.To,
+                    Body: 'test message',
+                  };
+    const callback = (err, result) => {
+      expect(err).toBeFalsy();
+      const twiml = result.toString();
+      expect(twiml).toMatch(
+        `<Message to="${context.MY_PHONE_NUMBER}">${event.From}: ${event.Body}</Message>`
+      );
+
+      done();
+    };
+
+    relaySms(context, event, callback);
+  });
+
+  it('should reject messages without a recipient specified', (done) => {
+    const event = { ...baseEvent,
+                    Body: 'no recipient specified',
+                  };
+    const callback = (err, result) => {
+      expect(err).toBeFalsy();
+      const twiml = result.toString();
+      expect(twiml).toMatch(
+        `<Message>You need to specify a recipient number and a ":" before the message.</Message>`
+      );
+
+      done();
+    };
+
+    relaySms(context, event, callback);
+  });
+
+  it('should send an error text on message send failure', (done) => {
+    shouldFail = true;
+    const event = { ...baseEvent };
+    const callback = (err, result) => {
+      expect(err).toBeFalsy();
+      const twiml = result.toString();
+      expect(twiml).toMatch(
+        `<Message>I couldn't understand the recipient phone number you entered.</Message>`
+      );
+
+      done();
+    };
+
+    relaySms(context, event, callback);
+  });
+});

--- a/masked-number/tests/relay-sms.test.js
+++ b/masked-number/tests/relay-sms.test.js
@@ -79,7 +79,7 @@ describe('masked-number function template', () => {
       expect(err).toBeFalsy();
       const twiml = result.toString();
       expect(twiml).toMatch(
-        `<Message>You need to specify a recipient number and a ":" before the message.</Message>`
+        `<Message>You need to specify a recipient number and a ":" before the message. For example, "+12223334444: message".</Message>`
       );
 
       done();
@@ -95,7 +95,7 @@ describe('masked-number function template', () => {
       expect(err).toBeFalsy();
       const twiml = result.toString();
       expect(twiml).toMatch(
-        `<Message>I couldn't understand the recipient phone number you entered.</Message>`
+        `<Message>There was an issue with the phone number you entered; please verify it is correct and try again.</Message>`
       );
 
       done();

--- a/templates.json
+++ b/templates.json
@@ -228,7 +228,7 @@
     {
       "id": "masked-number",
       "name": "Masked Phone Number",
-      "description": "Uses a Twilio phone number to relay SMS messages to and from your phone"
+      "description": "Uses a Twilio phone number to relay SMS messages to and from your phone, masking your phone number behind a Twilio phone number"
     }
   ]
 }

--- a/templates.json
+++ b/templates.json
@@ -224,6 +224,11 @@
       "id": "sms-broadcast",
       "name": "SMS Broadcast",
       "description": "Use a Twilio Notify service to subscribe users and broadcast messages to them"
+    },
+    {
+      "id": "masked-number",
+      "name": "Masked Phone Number",
+      "description": "Uses a Twilio phone number to relay SMS messages to and from your phone"
     }
   ]
 }


### PR DESCRIPTION
## Description

The masked-number template relays SMS messages to and from a personal
phone number, via a Twilio number. This is based on the code in the blog
post at
https://www.twilio.com/blog/sms-forwarding-and-responding-using-twilio-and-javascript

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
