### PR TITLE
Adds SMS Broadcast function from Twilio.org toolkit

### DIFF
--- a/sms-broadcast/.env
+++ b/sms-broadcast/.env
@@ -4,7 +4,7 @@
 # required: true
 BROADCAST_NOTIFY_SERVICE_SID=
 
-# description: # description: A comma separated list of numbers in E.164 format that are allowed to trigger a broadcast
+# description: A comma separated list of numbers in E.164 format that are allowed to trigger a broadcast
 # format: phone_number
 # required: true
 BROADCAST_ADMIN_NUMBERS=+12223334444,+491761234567

--- a/sms-broadcast/.env
+++ b/sms-broadcast/.env
@@ -1,0 +1,14 @@
+# description: SID of your Twilio Notify Service
+# format: sid
+# link: https://www.twilio.com/console/notify/services
+# required: true
+BROADCAST_NOTIFY_SERVICE_SID=
+
+# description: # description: A comma separated list of numbers in E.164 format that are allowed to trigger a broadcast
+# format: phone_number
+# required: true
+BROADCAST_ADMIN_NUMBERS=+12223334444,+491761234567
+
+# description: The path to the webhook
+# configurable: false
+TWILIO_SMS_WEBHOOK_URL=/broadcast

--- a/sms-broadcast/README.md
+++ b/sms-broadcast/README.md
@@ -1,0 +1,86 @@
+# SMS Broadcast
+
+Use this app to broadcast SMS messages to large numbers of people.
+
+## Pre-requisites
+
+### Environment variables
+
+This project requires some environment variables to be set. To keep your tokens and secrets secure, make sure to not commit the `.env` file in git. When setting up the project with `twilio serverless:init ...` the Twilio CLI will create a `.gitignore` file that excludes `.env` from the version history.
+
+In your `.env` file, set the following values:
+
+| Variable                     | Description                                                                                                                                                       | Required |
+| :--------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
+| BROADCAST_NOTIFY_SERVICE_SID | A Notify Service Sid which is connected to a Messaging Service. See below for setup instructions                                                                  | Yes      |
+| BROADCAST_ADMIN_NUMBERS      | A comma separated list of phone numbers (in [e.164 format](https://www.twilio.com/docs/glossary/what-e164)) that are allowed to broadcast messages to subscribers | Yes      |
+
+### Function Parameters
+
+`/broadcast` expects to receive an incoming webhook from an inbound SMS message. It is protected and requires a valid Twilio signature, it uses the `From` and `Body` parameters.
+
+## Setup
+
+### Create a new project with the template
+
+1. Install the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart#install-twilio-cli)
+2. Install the [serverless toolkit](https://www.twilio.com/docs/labs/serverless-toolkit/getting-started)
+
+```shell
+twilio plugins:install @twilio-labs/plugin-serverless
+```
+
+3. Initiate a new project
+
+```
+twilio serverless:init example --template=broadcast-sms && cd example
+```
+
+Before using this Function, you will need to create (or use an existing) Notify service and Messaging service. The Notify service will use the Messaging service to send out SMS messages. The Messaging service will be configured to send incoming messages to your Subscribe/Broadcast function.
+
+### Create a Messaging Service
+
+Go to the console and [create a messaging service](https://www.twilio.com/console/sms/services). Choose the "Notifications, Two-way" use case to preset some options on the service.
+
+Once created, click on the left nav link for "Numbers" and add (or buy) a phone number to use with this service. This will be the phone number(s) your end users will interact with.
+
+We'll need to come back here later - consider leaving this page open in a tab while you proceed to the next step in the console.
+
+### Create a Notify Service
+
+In the console, create a [Notify service](https://www.twilio.com/console/notify/services). Our function code uses Notify to store our subscriber list and to send out notifications. After your service is created, locate the Dropdown in your Notify service config labeled "Messaging Service SID". You should be able to choose the Messaging Service we created in the last step.
+
+You will need the generated SID for this service to configure your environment in the next step.
+
+Don't forget to save your changes!
+
+### Deploy the Function template
+
+Add the Notify Service SID to the `.env` file as `BROADCAST_NOTIFY_SERVICE_SID`. Add the phone numbers of admins that are permitted to send broadcast messages to the `.env` file as `BROADCAST_ADMIN_NUMBERS`.
+
+Deploy your functions and assets with the following command. Note: you must run this command from inside your project folder. [More details in the docs.](https://www.twilio.com/docs/labs/serverless-toolkit)
+
+To deploy the function with the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart) run the following:
+
+```
+twilio serverless:deploy
+```
+
+In a few moments your Function should be deployed! Grab its URL from the results, as we will now need to configure it for incoming SMS messages to our Messaging service.
+
+### Handle incoming messages with your Function
+
+Go back to the [messaging service](https://www.twilio.com/console/sms/services) you created earlier. In its configuration, you'll see a checkbox for "Handle Incoming Messages". Click this box to enable the feature. In the text box that appears, paste in the URL to the Function we just deployed. Click "Save".
+
+Now if all went well, you'll be able to start using your phone number for managing broadcasts and subscriptions!
+
+## Usage
+
+Once the Function is deployed and your Twilio phone number is set up, folks can text anything to it to receive a brief informational message about what commands are available.
+
+* `subscribe` - subscribes the current number for updates from the service
+* `stop` - uses Twilio's built-in stop handling to prevent a user from receiving messages
+* `start` - uses Twilio's built-in features to opt a user back in to receiving messages
+* `broadcast <message content>` - Administrators can use the broadcast command to send a message out to all subscribed users. Not included in help text.
+
+To edit the copy for any of the messages, open the function code and look for the text strings at the top of the file.

--- a/sms-broadcast/README.md
+++ b/sms-broadcast/README.md
@@ -79,8 +79,7 @@ Now if all went well, you'll be able to start using your phone number for managi
 Once the Function is deployed and your Twilio phone number is set up, folks can text anything to it to receive a brief informational message about what commands are available.
 
 * `subscribe` - subscribes the current number for updates from the service
-* `stop` - uses Twilio's built-in stop handling to prevent a user from receiving messages
-* `start` - uses Twilio's built-in features to opt a user back in to receiving messages
+* `stop/start` - uses Twilio's built-in stop handling to opt a user out from, or back in to, receiving messages (check out this article for [further details on Twilio's built-in features for handling opt-out/in keywords](https://support.twilio.com/hc/en-us/articles/223134027-Twilio-support-for-opt-out-keywords-SMS-STOP-filtering-))
 * `broadcast <message content>` - Administrators can use the broadcast command to send a message out to all subscribed users. Not included in help text.
 
 To edit the copy for any of the messages, open the function code and look for the text strings at the top of the file.

--- a/sms-broadcast/assets/index.html
+++ b/sms-broadcast/assets/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Get started with your Twilio Functions!</title>
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
+    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
+    <style>
+      body {
+        padding: 20px;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+      }
+
+      div[role="main"] {
+        flex: 1;
+      }
+
+      footer {
+        text-align: center;
+      }
+
+      footer p {
+        margin-bottom: 0;
+      }
+
+      #twilio-logo {
+        width: 50px;
+        height: 50px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Welcome to your new Twilio App</h1>
+    </header>
+    <div role="main">
+      <section>
+        <h3>Get started with your app</h3>
+        <p>Now that your code is deployed, here are the last steps you need to do to finish your app.</p>
+        <ol>
+          <li>Text anything to your Twilio app</li>
+          <li>You should receive a response saying "Hello! Text "subscribe" to receive updates, "stop" to stop getting messages, and "start" to receive them again."</li>
+          <li>Text "subscribe" to your Twilio app</li>
+          <li>You will be subscribed to future broadcasts and receive a response saying "Thanks! You have been subscribed for updates."</li>
+        </ol>
+        <p>From an admin phone number.</p>
+        <ol>
+          <li>Text "broadcast &lt;your message here&gt;"</li>
+          <li>The message will be sent out to all the subscribers.</li>
+          <li>You will receive a response saying "Boom! Message broadcast to all subscribers."</li>
+        </ol>
+      </section>
+      <section>
+        <h3>Troubleshooting</h3>
+        <ul>
+          <li>Make sure you have set up the Notify Service and Messaging Service correctly</li>
+          <li>Make sure that the Messaging Service is setup to handle incoming messages and the webhook is configured to point at:</li>
+          <p>
+            <pre><code><span class="function-root"></span>/broadcast</code></pre>
+          </p>
+          <li>Check the
+            <code>README.md</code>
+            of your project</li>
+        </ul>
+      </section>
+    </div>
+    <footer>
+      <p>
+        <a href="https://www.twilio.com/">
+          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+            <defs>
+              <style>
+                .cls-1 {
+                  fill: #f22f46;
+                }
+              </style>
+            </defs>
+            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+        </a>
+      </p>
+      <p>
+        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
+      </p>
+    </footer>
+
+    <script>
+      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
+      const baseUrl = new URL(location.href);
+      baseUrl.pathname = baseUrl
+        .pathname
+        .replace(/\/index\.html$/, '');
+      delete baseUrl.hash;
+      delete baseUrl.search;
+      const fullUrl = baseUrl
+        .href
+        .substr(0, baseUrl.href.length - 1);
+      const functionRoots = document.querySelectorAll('span.function-root');
+
+      functionRoots.forEach(element => {
+        element.innerText = fullUrl
+      })
+    </script>
+  </body>
+</html>

--- a/sms-broadcast/functions/broadcast.protected.js
+++ b/sms-broadcast/functions/broadcast.protected.js
@@ -1,0 +1,129 @@
+/* global module, exports, require, process, console */
+"use strict";
+
+// Response strings - update these to change the copy in the messages
+const helpMessage =
+  'Hello! Text "subscribe" to receive updates, "stop" to stop getting messages, and "start" to receive them again.';
+const subscribeSuccessMessage = "Thanks! You have been subscribed for updates.";
+const subscribeFailMessage =
+  "Dang it. We couldn't subscribe you - try again later?";
+const broadcastNotAuthorizedMessage =
+  "Your phone number is not authorized to broadcast in this application";
+const broadcastSuccessMessage = "Boom! Message broadcast to all subscribers.";
+const broadcastFailMessage =
+  "Well this is awkward. Your message failed to send, try again later.";
+
+// Helper class for commands
+class Command {
+  // Create a new instance with necessary arguments from the incoming SMS
+  constructor(event, context) {
+    this.fromNumber = event.From;
+    this.body = event.Body || "";
+    this.event = event;
+    this.context = context;
+
+    const client = this.context.getTwilioClient();
+    this.notify = client.notify.services(
+      process.env.BROADCAST_NOTIFY_SERVICE_SID
+    );
+
+    // Occassionally, US numbers will be passed without the preceding
+    // country code - check for this eventuality and fix it
+    if (this.fromNumber.indexOf("+") !== 0) {
+      this.fromNumber = `+1${this.fromNumber}`;
+    }
+  }
+
+  // Get an array of arguments after the first word for a command
+  get commandArguments() {
+    return this.body.trim().split(" ").slice(1);
+  }
+
+  // Get the full text after the command with spaces reinserted
+  get commandText() {
+    return this.commandArguments.join(" ");
+  }
+
+  // Execute command async (to be overridden by subclasses)
+  run(callback) {
+    callback(null, "Command not implemented.");
+  }
+}
+
+/* Subclasses for supported commands */
+
+class HelpCommand extends Command {
+  run(callback) {
+    callback(null, helpMessage);
+  }
+}
+
+class SubscribeCommand extends Command {
+  run(callback) {
+    // Create a new SMS Notify binding for this user's phone number
+    this.notify.bindings
+      .create({
+        identity: this.fromNumber,
+        bindingType: "sms",
+        address: this.fromNumber,
+      })
+      .then(() => {
+        callback(null, subscribeSuccessMessage);
+      })
+      .catch((err) => {
+        console.error(err);
+        callback(err, subscribeFailMessage);
+      });
+  }
+}
+
+class BroadcastCommand extends Command {
+  constructor(event, context) {
+    super(event, context);
+    this.adminNumbers = context.BROADCAST_ADMIN_NUMBERS;
+  }
+
+  run(callback) {
+    // Check if sender is in list of admins, stored in the system environment
+    // as a comma-separated string
+    if (this.adminNumbers.indexOf(this.fromNumber) < 0) {
+      return callback(null, broadcastNotAuthorizedMessage);
+    }
+
+    // Create a new Notification for all bindings with the text of the message
+    this.notify.notifications
+      .create({
+        tag: "all",
+        body: this.commandText,
+      })
+      .then(() => {
+        callback(null, broadcastSuccessMessage);
+      })
+      .catch((err) => {
+        console.error(err);
+        callback(err, broadcastFailMessage);
+      });
+  }
+}
+
+// Handle incoming SMS commands
+exports.handler = (context, event, callback) => {
+  // Get command text from incoming SMS body
+  let cmd = event.Body || "";
+  cmd = cmd.trim().split(" ")[0].toLowerCase();
+
+  // Choose other commands as appropriate
+  const CommandClasses = {
+    "subscribe": SubscribeCommand,
+    "broadcast": BroadcastCommand
+  }
+  const CommandClass = CommandClasses[cmd] || HelpCommand;
+  const cmdInstance = new CommandClass(event, context)
+
+  // Execute command
+  cmdInstance.run((err, message) => {
+    const twiml = new Twilio.twiml.MessagingResponse();
+    twiml.message(message);
+    callback(null, twiml);
+  });
+};

--- a/sms-broadcast/package.json
+++ b/sms-broadcast/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "sms-broadcast",
+  "dependencies": {}
+}

--- a/sms-broadcast/tests/broadcast.test.js
+++ b/sms-broadcast/tests/broadcast.test.js
@@ -1,0 +1,215 @@
+const helpers = require("../../test/test-helper");
+const broadcast = require("../functions/broadcast.protected").handler;
+const Twilio = require("twilio");
+
+let mockService;
+const mockClient = {
+  notify: {
+    services: jest.fn(() => mockService),
+  },
+};
+
+const context = {
+  BROADCAST_NOTIFY_SERVICE_SID: "ISXXXXXXX",
+  BROADCAST_ADMIN_NUMBERS: "+12345",
+  getTwilioClient: jest.fn(() => mockClient),
+};
+
+afterAll(() => {
+  helpers.teardown();
+});
+
+describe("help", () => {
+  test("returns help text without a recognised command", (done) => {
+    helpers.setup(context);
+    const callback = (err, result) => {
+      expect(result).toBeInstanceOf(Twilio.twiml.MessagingResponse);
+      expect(result.toString()).toMatch(
+        '<Message>Hello! Text "subscribe" to receive updates, "stop" to stop getting messages, and "start" to receive them again.</Message>'
+      );
+      done();
+    };
+
+    const event = {
+      Body: "nothing",
+      From: "+1555123456",
+    };
+
+    broadcast(context, event, callback);
+  });
+
+  test("returns help text without a command at all", (done) => {
+    helpers.setup(context);
+    const callback = (err, result) => {
+      expect(result).toBeInstanceOf(Twilio.twiml.MessagingResponse);
+      expect(result.toString()).toMatch(
+        '<Message>Hello! Text "subscribe" to receive updates, "stop" to stop getting messages, and "start" to receive them again.</Message>'
+      );
+      done();
+    };
+
+    const event = {
+      Body: "",
+      From: "+1555123456",
+    };
+
+    broadcast(context, event, callback);
+  });
+});
+
+describe("subscribing", () => {
+  test("successfully subscribes a phone number by creating a binding", (done) => {
+    helpers.setup(context);
+
+    mockService = {
+      bindings: {
+        create: jest.fn(() => Promise.resolve()),
+      },
+    };
+
+    const event = {
+      Body: "subscribe",
+      From: "+1555123456",
+    };
+
+    const callback = (err, result) => {
+      expect(mockService.bindings.create).toHaveBeenCalledTimes(1);
+      expect(mockService.bindings.create).toHaveBeenCalledWith({
+        identity: event.From,
+        bindingType: "sms",
+        address: event.From,
+      });
+      expect(result).toBeInstanceOf(Twilio.twiml.MessagingResponse);
+      expect(result.toString()).toMatch(
+        "<Message>Thanks! You have been subscribed for updates.</Message>"
+      );
+      done();
+    };
+
+    broadcast(context, event, callback);
+  });
+
+  test("returns an error message if creating the binding fails", (done) => {
+    helpers.setup(context);
+
+    const error = "Failed";
+
+    mockService = {
+      bindings: {
+        create: jest.fn(() => Promise.reject(error)),
+      },
+    };
+
+    console.error = jest.fn();
+
+    const event = {
+      Body: "subscribe",
+      From: "+1555123456",
+    };
+
+    const callback = (err, result) => {
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith(error);
+      expect(mockService.bindings.create).toHaveBeenCalledTimes(1);
+      expect(mockService.bindings.create).toHaveBeenCalledWith({
+        identity: event.From,
+        bindingType: "sms",
+        address: event.From,
+      });
+      expect(result).toBeInstanceOf(Twilio.twiml.MessagingResponse);
+      expect(result.toString()).toMatch(
+        "<Message>Dang it. We couldn't subscribe you - try again later?</Message>"
+      );
+      done();
+    };
+
+    broadcast(context, event, callback);
+  });
+});
+
+describe("broadcasting", () => {
+  test("returns message if from number is not an admin", (done) => {
+    helpers.setup(context);
+
+    const callback = (err, result) => {
+      expect(result).toBeInstanceOf(Twilio.twiml.MessagingResponse);
+      expect(result.toString()).toMatch(
+        "<Message>Your phone number is not authorized to broadcast in this application</Message>"
+      );
+      done();
+    };
+
+    const event = {
+      Body: "broadcast this is a great message",
+      From: "+1555123456",
+    };
+
+    broadcast(context, event, callback);
+  });
+
+  test("creates a notification and returns a success message when an admin sends a broadcast", (done) => {
+    helpers.setup(context);
+
+    mockService = {
+      notifications: {
+        create: jest.fn(() => Promise.resolve()),
+      },
+    };
+
+    const callback = (err, result) => {
+      expect(mockService.notifications.create).toHaveBeenCalledTimes(1);
+      expect(mockService.notifications.create).toHaveBeenCalledWith({
+        tag: "all",
+        body: "this is a great message",
+      });
+      expect(result).toBeInstanceOf(Twilio.twiml.MessagingResponse);
+      expect(result.toString()).toMatch(
+        "<Message>Boom! Message broadcast to all subscribers.</Message>"
+      );
+      done();
+    };
+
+    const event = {
+      Body: "broadcast this is a great message",
+      From: "+12345",
+    };
+
+    broadcast(context, event, callback);
+  });
+
+  test("returns an error message if the notification fails", (done) => {
+    helpers.setup(context);
+
+    const error = "Failed";
+
+    mockService = {
+      notifications: {
+        create: jest.fn(() => Promise.reject(error)),
+      },
+    };
+
+    console.error = jest.fn();
+
+    const callback = (err, result) => {
+      expect(mockService.notifications.create).toHaveBeenCalledTimes(1);
+      expect(mockService.notifications.create).toHaveBeenCalledWith({
+        tag: "all",
+        body: "this is a great message",
+      });
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith(error);
+      expect(result).toBeInstanceOf(Twilio.twiml.MessagingResponse);
+      expect(result.toString()).toMatch(
+        "<Message>Well this is awkward. Your message failed to send, try again later.</Message>"
+      );
+      done();
+    };
+
+    const event = {
+      Body: "broadcast this is a great message",
+      From: "+12345",
+    };
+
+    broadcast(context, event, callback);
+  });
+});

--- a/templates.json
+++ b/templates.json
@@ -219,6 +219,11 @@
       "id": "json-webhook",
       "name": "JSON Webhook Adapter",
       "description": "Forward a URL encoded Twilio webhook event to a JSON webhook, suitable for use with services like Zapier and IFTTT"
+    },
+    {
+      "id": "sms-broadcast",
+      "name": "SMS Broadcast",
+      "description": "Use a Twilio Notify service to subscribe users and broadcast messages to them"
     }
   ]
 }


### PR DESCRIPTION
## Description

This adds the [SMS Broadcast template from Twilio.org's toolkit](https://github.com/Twilio-org/toolkit/blob/master/docs/broadcast.md).

## Checklist

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).
