### PR TITLE
feat(templates): Add international tel input example template

### DIFF
--- a/international-telephone-input/README.md
+++ b/international-telephone-input/README.md
@@ -38,7 +38,7 @@ twilio plugins:install @twilio-labs/plugin-serverless
 3. Initiate a new project
 
 ```
-twilio serverless:init phone-input-sample --template=telinput && cd phone-input-sample
+twilio serverless:init phone-input-sample --template=international-telephone-input && cd phone-input-sample
 ```
 
 4. Add your environment variables to `.env`:

--- a/international-telephone-input/README.md
+++ b/international-telephone-input/README.md
@@ -1,0 +1,66 @@
+# International telephone input validation
+
+This project will show you one way to validate phone number inputs with the `intl-tel-input` library and Twilio's [Lookup API](https://www.twilio.com/docs/lookup/api). For a production use case we recommend adding [phone verification](https://github.com/twilio-labs/function-templates/tree/main/verify), which is a best practice for collecting phone numbers from your users in order to make sure they have control of the number.
+
+## How to use the template
+
+The best way to use the Function templates is through the Twilio CLI as described below. If you'd like to use the template without the Twilio CLI, [check out our usage docs](../docs/USING_FUNCTIONS.md).
+
+### Environment variables
+
+This project requires some environment variables to be set. To keep your tokens and secrets secure, make sure to not commit the `.env` file in git. When setting up the project with `twilio serverless:init ...` the Twilio CLI will create a `.gitignore` file that excludes `.env` from the version history.
+
+In your `.env` file, set the following values:
+
+| Variable             | Meaning                                                           | Required |
+| :------------------- | :---------------------------------------------------------------- | :------- |
+| `ACCOUNT_SID`        | Find in the [console](https://www.twilio.com/console)             | Yes      |
+| `AUTH_TOKEN`         | Find in the [console](https://www.twilio.com/console)             | Yes      |
+
+### Function Parameters
+
+`lookup.js` expects the following parameters:
+
+| Parameter      | Description                                 | Required |
+| :------------- | :------------------------------------------ | :------- |
+| `phone`        | Phone number in [E.164 format](https://www.twilio.com/docs/glossary/what-e164) | Yes |
+
+
+## Create a new project with the template
+
+1. Install the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart#install-twilio-cli)
+2. Install the [serverless toolkit](https://www.twilio.com/docs/labs/serverless-toolkit/getting-started)
+
+```shell
+twilio plugins:install @twilio-labs/plugin-serverless
+```
+
+3. Initiate a new project
+
+```
+twilio serverless:init phone-input-sample --template=telinput && cd phone-input-sample
+```
+
+4. Add your environment variables to `.env`:
+
+Make sure variables are populated in your `.env` file. See [Environment variables](#environment-variables).
+
+5. Start the server :
+
+```
+npm start
+```
+
+5. Open the web page at https://localhost:3000/index.html and enter your phone number to test
+
+ℹ️ Check the developer console and terminal for any errors, make sure you've set your environment variables.
+
+## Deploying
+
+Deploy your functions and assets with either of the following commands. Note: you must run these commands from inside your project folder. [More details in the docs.](https://www.twilio.com/docs/labs/serverless-toolkit)
+
+With the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart):
+
+```
+twilio serverless:deploy
+```

--- a/international-telephone-input/README.md
+++ b/international-telephone-input/README.md
@@ -1,6 +1,6 @@
 # International telephone input validation
 
-This project will show you one way to validate phone number inputs with the `intl-tel-input` library and Twilio's [Lookup API](https://www.twilio.com/docs/lookup/api). For a production use case we recommend adding [phone verification](https://github.com/twilio-labs/function-templates/tree/main/verify), which is a best practice for collecting phone numbers from your users in order to make sure they have control of the number.
+This project will show you one way to validate phone number inputs with the [`intl-tel-input`](https://github.com/jackocnr/intl-tel-input) plugin and Twilio's [Lookup API](https://www.twilio.com/docs/lookup/api). For a production use case we recommend adding [phone verification](https://github.com/twilio-labs/function-templates/tree/main/verify), which is a best practice for collecting phone numbers from your users in order to make sure they have control of the number.
 
 ## How to use the template
 

--- a/international-telephone-input/assets/index.html
+++ b/international-telephone-input/assets/index.html
@@ -73,6 +73,7 @@
           info.style.display = "";
           info.innerHTML = `Phone number in E.164 format: <strong>${phoneNumber}</strong>`
         } else {
+          console.log(json.error);
           error.style.display = "";
           error.innerHTML = `Invalid phone number.`
         }

--- a/international-telephone-input/assets/index.html
+++ b/international-telephone-input/assets/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>International telephone input</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/16.0.11/css/intlTelInput.css"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/16.0.11/js/intlTelInput.min.js"></script>
+  </head>
+  <body>
+    <div class="container">
+      <h1>International telephone input</h1>
+      <p>
+        This example shows how to process and parse international phone numbers with the
+        <a href="https://github.com/jackocnr/intl-tel-input"><code>intl-tel-input</code></a>
+        library and detect invalid phone numbers with the
+        <a href="https://twilio.com/docs/lookup/api">Twilio Lookup API</a>.
+      </p>
+      <div>
+        <form id="login" onsubmit="process(event)">
+          <div class="phone-input">
+            <p>Enter your phone number:</p>
+            <input type="tel" id="phone" class="form-control" />
+          </div>
+          <div>
+            <input type="submit" class="btn" value="Verify" />
+          </div>
+        </form>
+      <div class="alert alert-info" style="display: none;"></div>
+      <div class="alert alert-error" style="display: none;"></div>
+    </div>
+  </body>
+  <script>
+    // Handle international prefixes, format phone input field
+    // Uses intl-tel-input library
+    const phoneInputField = document.querySelector("#phone");
+    const phoneInput = window.intlTelInput(phoneInputField, {
+      // https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+      preferredCountries: ["us", "co", "in", "de"],
+      separateDialCode: true,
+      utilsScript:
+        "https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/16.0.11/js/utils.js",
+    });
+
+    const info = document.querySelector(".alert-info")
+    const error = document.querySelector(".alert-error")
+
+    function process(event) {
+      event.preventDefault();
+
+      info.style.display = "none";
+      error.style.display = "none";
+
+      const phoneNumber = phoneInput.getNumber();
+
+      // OPTION 1 - Twilio Lookup API
+      // Pros: Free API call, updated data
+      // Pros: The Lookup API can return line type and carrier info too: https://www.twilio.com/docs/lookup/api
+      // Cons: Network request
+      const data = new URLSearchParams();
+      data.append("phone", phoneNumber);
+
+      fetch("./lookup", {
+        method: 'POST',
+        body: data
+      })
+      .then(response => response.json())
+      .then(json => {
+        if (json.success) {
+          info.style.display = "";
+          info.innerHTML = `Phone number in E.164 format: <strong>${phoneNumber}</strong>`
+        } else {
+          error.style.display = "";
+          error.innerHTML = `Invalid phone number.`
+        }
+      })
+      .catch(err => {
+        error.style.display = "";
+        error.innerHTML = `Something went wrong: ${err}`
+      });
+
+      // OPTION 2 - intl-tel-input validity check
+      // Pros: No additional API call
+      // Cons: Requires updating the library for updates to phone number validity
+      // if (phoneInput.isValidNumber()) {
+      //   info.style.display = "";
+      //   info.innerHTML = `Phone number in E.164 format: <strong>${phoneNumber}</strong>`
+      // } else {
+      //   error.style.display = "";
+      //   error.innerHTML = `Invalid phone number.`
+      // }
+    }
+  </script>
+</html>

--- a/international-telephone-input/assets/index.html
+++ b/international-telephone-input/assets/index.html
@@ -18,9 +18,10 @@
         <a href="https://github.com/jackocnr/intl-tel-input"><code>intl-tel-input</code></a>
         library and detect invalid phone numbers with the
         <a href="https://twilio.com/docs/lookup/api">Twilio Lookup API</a>.
+        Learn more in <a href="https://www.twilio.com/blog/international-phone-number-input-html-javascript">this blog post.</a>
       </p>
       <div>
-        <form id="login" onsubmit="process(event)">
+        <form id="lookup">
           <p>Enter your phone number:</p>
           <input id="phone" type="tel" name="phone">
           <input type="submit" class="btn" value="Verify" />
@@ -88,6 +89,9 @@
         //   error.innerHTML = `Invalid phone number.`
         // }
       }
+
+      const form = document.getElementById("lookup");
+      form.addEventListener("submit", process);
     </script>
   </body>
 </html>

--- a/international-telephone-input/assets/index.html
+++ b/international-telephone-input/assets/index.html
@@ -3,12 +3,12 @@
   <head>
     <title>International telephone input</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="styles.css" />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/16.0.11/css/intlTelInput.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/css/intlTelInput.css"
     />
-    <link rel="stylesheet" href="styles.css" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/16.0.11/js/intlTelInput.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/js/intlTelInput.min.js"></script>
   </head>
   <body>
     <div class="container">
@@ -21,78 +21,73 @@
       </p>
       <div>
         <form id="login" onsubmit="process(event)">
-          <div class="phone-input">
-            <p>Enter your phone number:</p>
-            <input type="tel" id="phone" class="form-control" />
-          </div>
-          <div>
-            <input type="submit" class="btn" value="Verify" />
-          </div>
+          <p>Enter your phone number:</p>
+          <input id="phone" type="tel" name="phone">
+          <input type="submit" class="btn" value="Verify" />
         </form>
       <div class="alert alert-info" style="display: none;"></div>
       <div class="alert alert-error" style="display: none;"></div>
     </div>
-  </body>
-  <script>
-    // Handle international prefixes, format phone input field
-    // Uses intl-tel-input library
-    const phoneInputField = document.querySelector("#phone");
-    const phoneInput = window.intlTelInput(phoneInputField, {
-      // https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
-      preferredCountries: ["us", "co", "in", "de"],
-      separateDialCode: true,
-      utilsScript:
-        "https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/16.0.11/js/utils.js",
-    });
-
-    const info = document.querySelector(".alert-info")
-    const error = document.querySelector(".alert-error")
-
-    function process(event) {
-      event.preventDefault();
-
-      info.style.display = "none";
-      error.style.display = "none";
-
-      const phoneNumber = phoneInput.getNumber();
-
-      // OPTION 1 - Twilio Lookup API
-      // Pros: Free API call, updated data
-      // Pros: The Lookup API can return line type and carrier info too: https://www.twilio.com/docs/lookup/api
-      // Cons: Network request
-      const data = new URLSearchParams();
-      data.append("phone", phoneNumber);
-
-      fetch("./lookup", {
-        method: 'POST',
-        body: data
-      })
-      .then(response => response.json())
-      .then(json => {
-        if (json.success) {
-          info.style.display = "";
-          info.innerHTML = `Phone number in E.164 format: <strong>${phoneNumber}</strong>`
-        } else {
-          console.log(json.error);
-          error.style.display = "";
-          error.innerHTML = `Invalid phone number.`
-        }
-      })
-      .catch(err => {
-        error.style.display = "";
-        error.innerHTML = `Something went wrong: ${err}`
+    <script>
+      // Handle international prefixes, format phone input field
+      // Uses intl-tel-input plugin
+      const phoneInputField = document.querySelector("#phone");
+      const phoneInput = window.intlTelInput(phoneInputField, {
+        // https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+        preferredCountries: ["us", "co", "in", "de"],
+        utilsScript:
+          "https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/js/utils.js",
       });
 
-      // OPTION 2 - intl-tel-input validity check
-      // Pros: No additional API call
-      // Cons: Requires updating the library for updates to phone number validity
-      // if (phoneInput.isValidNumber()) {
-      //   info.style.display = "";
-      //   info.innerHTML = `Phone number in E.164 format: <strong>${phoneNumber}</strong>`
-      // } else {
-      //   error.style.display = "";
-      //   error.innerHTML = `Invalid phone number.`
-      // }
-    }
-  </script>
+      const info = document.querySelector(".alert-info");
+      const error = document.querySelector(".alert-error");
+
+      function process(event) {
+        event.preventDefault();
+
+        const phoneNumber = phoneInput.getNumber();
+
+        info.style.display = "none";
+        error.style.display = "none";
+
+        // OPTION 1 - Twilio Lookup API
+        // Pros: Free API call, updated data
+        // Pros: The Lookup API can return line type and carrier info too: https://www.twilio.com/docs/lookup/api
+        // Cons: Network request
+        const data = new URLSearchParams();
+        data.append("phone", phoneNumber);
+
+        fetch("./lookup", {
+          method: 'POST',
+          body: data
+        })
+        .then(response => response.json())
+        .then(json => {
+          if (json.success) {
+            info.style.display = "";
+            info.innerHTML = `Phone number in E.164 format: <strong>${phoneNumber}</strong>`
+          } else {
+            console.log(json.error);
+            error.style.display = "";
+            error.innerHTML = `Invalid phone number.`
+          }
+        })
+        .catch(err => {
+          error.style.display = "";
+          error.innerHTML = `Something went wrong: ${err}`
+        });
+
+        // OPTION 2 - intl-tel-input validity check
+        // Pros: No additional API call
+        // Cons: Requires plugin updates for updates on phone number validity
+        // if (phoneInput.isValidNumber()) {
+        //   info.style.display = "";
+        //   info.innerHTML = `Phone number in E.164 format: <strong>${phoneNumber}</strong>`
+        // } else {
+        //   error.style.display = "";
+        //   error.innerHTML = `Invalid phone number.`
+        // }
+      }
+    </script>
+  </body>
 </html>

--- a/international-telephone-input/assets/styles.css
+++ b/international-telephone-input/assets/styles.css
@@ -9,26 +9,30 @@ body {
   padding: 10px;
 }
 
-.btn {
-  margin-top: 10px;
-  padding: 6px 12px;
-  color: #333;
-  background-color: #fff;
+#phone, .btn {
+  padding-top: 6px;
+  padding-bottom: 6px;
   border: 1px solid #ccc;
   border-radius: 4px;
+}
+
+.btn {
+  color: #ffffff;
+  background-color: #428BCA;
+  border-color: #357EBD;
   font-size: 14px;
   outline: none;
   cursor: pointer;
+  padding-left: 12px;
+  padding-right: 12px;
 }
 
 .btn:focus, .btn:hover {
-  background-color: #e6e6e6;
-  border-color: #8c8c8c;
+  background-color: #3276B1;
+  border-color: #285E8E;
 }
 
 .btn:active {
-  background-color: #e6e6e6;
-  border-color: #adadad;
   box-shadow: inset 0 3px 5px rgba(0,0,0,.125);
 }
 

--- a/international-telephone-input/assets/styles.css
+++ b/international-telephone-input/assets/styles.css
@@ -1,0 +1,52 @@
+body {
+  font-family: Helvetica, sans-serif;
+}
+
+.container {
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 10px;
+}
+
+.btn {
+  margin-top: 10px;
+  padding: 6px 12px;
+  color: #333;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 14px;
+  outline: none;
+  cursor: pointer;
+}
+
+.btn:focus, .btn:hover {
+  background-color: #e6e6e6;
+  border-color: #8c8c8c;
+}
+
+.btn:active {
+  background-color: #e6e6e6;
+  border-color: #adadad;
+  box-shadow: inset 0 3px 5px rgba(0,0,0,.125);
+}
+
+.alert {
+  padding: 15px;
+  margin-top: 10px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+}
+
+.alert-info {
+  border-color: #bce8f1;
+  color: #31708f;
+  background-color: #d9edf7;
+}
+
+.alert-error {
+  color: #a94442;
+  background-color: #f2dede;
+  border-color: #ebccd1;
+}

--- a/international-telephone-input/functions/lookup.js
+++ b/international-telephone-input/functions/lookup.js
@@ -22,7 +22,7 @@ exports.handler = function (context, event, callback) {
   // response.appendHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
   // response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
 
-  if (typeof event.phone === "undefined") {
+  if (event.phone === "") {
     response.setBody({
       success: false,
       error: "Missing parameter; please provide a phone number.",

--- a/international-telephone-input/functions/lookup.js
+++ b/international-telephone-input/functions/lookup.js
@@ -22,7 +22,7 @@ exports.handler = function (context, event, callback) {
   // response.appendHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
   // response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
 
-  if (event.phone === "") {
+  if (event.phone === "" || typeof event.phone === "undefined") {
     response.setBody({
       success: false,
       error: "Missing parameter; please provide a phone number.",

--- a/international-telephone-input/functions/lookup.js
+++ b/international-telephone-input/functions/lookup.js
@@ -1,0 +1,64 @@
+/**
+ *  Lookup - validate a phone number
+ *
+ *  This function will tell you whether or not a phone number is valid using Twilio's Lookup API
+ *
+ *  Parameters:
+ *  "phone" - string - phone number in E.164 format (https://www.twilio.com/docs/glossary/what-e164)
+ *
+ *  Returns JSON
+ *  {
+ *    "success": boolean,
+ *    "error": {                // not present if success is true
+ *      "message": string,
+ *      "moreInfo": url string
+ *    }
+ *  }
+ */
+
+exports.handler = function (context, event, callback) {
+  const response = new Twilio.Response();
+  response.appendHeader("Content-Type", "application/json");
+
+  // uncomment to support CORS
+  // response.appendHeader('Access-Control-Allow-Origin', '*');
+  // response.appendHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  // response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (typeof event.phone === "undefined") {
+    response.setBody({
+      success: false,
+      error: {
+        message: "Missing parameter; please provide a phone number.",
+        moreInfo: "https://www.twilio.com/docs/lookup/api",
+      },
+    });
+    response.setStatusCode(400);
+    return callback(null, response);
+  }
+
+  const client = context.getTwilioClient();
+
+  client.lookups
+    .phoneNumbers(event.phone)
+    .fetch()
+    .then((resp) => {
+      response.setStatusCode(200);
+      response.setBody({
+        success: true,
+      });
+      callback(null, response);
+    })
+    .catch((error) => {
+      console.log(error);
+      response.setStatusCode(error.status);
+      response.setBody({
+        success: false,
+        error: {
+          message: error.message,
+          moreInfo: error.moreInfo,
+        },
+      });
+      callback(null, response);
+    });
+};

--- a/international-telephone-input/functions/lookup.js
+++ b/international-telephone-input/functions/lookup.js
@@ -9,10 +9,7 @@
  *  Returns JSON
  *  {
  *    "success": boolean,
- *    "error": {                // not present if success is true
- *      "message": string,
- *      "moreInfo": url string
- *    }
+ *    "error": string      // not present if success is true
  *  }
  */
 
@@ -28,10 +25,7 @@ exports.handler = function (context, event, callback) {
   if (typeof event.phone === "undefined") {
     response.setBody({
       success: false,
-      error: {
-        message: "Missing parameter; please provide a phone number.",
-        moreInfo: "https://www.twilio.com/docs/lookup/api",
-      },
+      error: "Missing parameter; please provide a phone number.",
     });
     response.setStatusCode(400);
     return callback(null, response);
@@ -54,10 +48,7 @@ exports.handler = function (context, event, callback) {
       response.setStatusCode(error.status);
       response.setBody({
         success: false,
-        error: {
-          message: error.message,
-          moreInfo: error.moreInfo,
-        },
+        error: error.message,
       });
       callback(null, response);
     });

--- a/international-telephone-input/package.json
+++ b/international-telephone-input/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "telinput",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "twilio-run",
+    "deploy": "twilio-run deploy"
+  },
+  "dependencies": {
+    "twilio": "^3.55.1"
+  },
+  "devDependencies": {
+    "twilio-run": "^2.6.0"
+  },
+  "engines": {
+    "node": "10"
+  }
+}

--- a/international-telephone-input/package.json
+++ b/international-telephone-input/package.json
@@ -1,19 +1,5 @@
 {
-  "name": "telinput",
-  "version": "0.0.0",
-  "private": true,
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "twilio-run",
-    "deploy": "twilio-run deploy"
-  },
   "dependencies": {
     "twilio": "^3.55.1"
-  },
-  "devDependencies": {
-    "twilio-run": "^2.6.0"
-  },
-  "engines": {
-    "node": "10"
   }
 }

--- a/international-telephone-input/tests/lookup.test.js
+++ b/international-telephone-input/tests/lookup.test.js
@@ -1,0 +1,59 @@
+const lookupFunction = require("../functions/lookup").handler;
+const helpers = require("../../test/test-helper");
+
+const mockFetch = {
+  fetch: jest.fn(() => Promise.resolve({ sid: "sid" })),
+};
+
+const mockClient = {
+  lookups: {
+    phoneNumbers: jest.fn(() => mockFetch),
+  },
+};
+
+const testContext = {
+  getTwilioClient: () => mockClient,
+};
+
+describe("international-telephone-input/lookup", () => {
+  beforeAll(() => {
+    helpers.setup({});
+  });
+  afterAll(() => {
+    helpers.teardown();
+  });
+
+  test("returns an error response when required parameter is missing", (done) => {
+    const callback = (err, result) => {
+      expect(result).toBeDefined();
+      expect(result._body.success).toEqual(false);
+      done();
+    };
+    const event = {};
+    lookupFunction(testContext, event, callback);
+  });
+
+  test("returns an error response when required parameter is empty", (done) => {
+    const callback = (err, result) => {
+      expect(result).toBeDefined();
+      expect(result._body.success).toEqual(false);
+      done();
+    };
+    const event = {
+      phone: "",
+    };
+    lookupFunction(testContext, event, callback);
+  });
+
+  test("returns success with valid request", (done) => {
+    const callback = (err, result) => {
+      expect(result).toBeDefined();
+      expect(result._body.success).toEqual(true);
+      done();
+    };
+    const event = {
+      phone: "+17341234567",
+    };
+    lookupFunction(testContext, event, callback);
+  });
+});

--- a/templates.json
+++ b/templates.json
@@ -211,6 +211,11 @@
       "description": "Helpful dashboard for testing and debugging during your development with Twilio Verify."
     },
     {
+      "id": "international-telephone-input",
+      "name": "International telephone input",
+      "description": "International telephone input form field and phone number validation with Twilio Lookup."
+    },
+    {
       "id": "forward-message-mailgun",
       "name": "Forward SMS message as an email (Mailgun)",
       "description": "The function will forward incoming SMS messages to an email address using the Mailgun API"


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

Show off how to use the intl-tel-input library in combination with Lookup to build international input fields and detect invalid phone numbers.

Demo: https://telinput-4826-dev.twil.io/index.html

Side note - this project doesn't require any additional environment variables, but the tests failed when I didn't add a .env file, so I left it empty.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
