### PR TITLE
Disable calls by default for the verify template

### DIFF
--- a/verify/functions/start-verify.js
+++ b/verify/functions/start-verify.js
@@ -19,23 +19,39 @@
  *  }
  */
 
-exports.handler = function(context, event, callback) {
+exports.handler = function (context, event, callback) {
   const response = new Twilio.Response();
-  response.appendHeader('Content-Type', 'application/json');
-  
+  response.appendHeader("Content-Type", "application/json");
+
   // uncomment to support CORS
   // response.appendHeader('Access-Control-Allow-Origin', '*');
   // response.appendHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
   // response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
 
-  if (typeof event.to === 'undefined') {
+  if (typeof event.to === "undefined") {
     response.setBody({
-      "success": false,
-      "error": {
-        "message": "Missing parameter; please provide a phone number or email.",
-        "moreInfo": "https://www.twilio.com/docs/verify/api/verification"
-      }
-    })
+      success: false,
+      error: {
+        message: "Missing parameter; please provide a phone number or email.",
+        moreInfo: "https://www.twilio.com/docs/verify/api/verification",
+      },
+    });
+    response.setStatusCode(400);
+    return callback(null, response);
+  }
+
+  // DELETE THIS BLOCK IF YOU WANT TO ENABLE THE VOICE CHANNEL
+  // Learn more about toll fraud
+  // https://www.twilio.com/docs/verify/preventing-toll-fraud
+  if (event.channel === "call") {
+    response.setBody({
+      success: false,
+      error: {
+        message:
+          "Calls disabled by default. Update the code in <code>start-verify.js</code> to enable.",
+        moreInfo: "https://www.twilio.com/docs/verify/preventing-toll-fraud",
+      },
+    });
     response.setStatusCode(400);
     return callback(null, response);
   }
@@ -43,33 +59,33 @@ exports.handler = function(context, event, callback) {
   const client = context.getTwilioClient();
   const service = context.VERIFY_SERVICE_SID;
   const to = event.to;
-  const channel = (typeof event.channel === 'undefined') ? "sms" : event.channel;
-  const locale = (typeof event.locale === 'undefined') ? "en" : event.locale;
+  const channel = typeof event.channel === "undefined" ? "sms" : event.channel;
+  const locale = typeof event.locale === "undefined" ? "en" : event.locale;
 
-  client.verify.services(service)
-    .verifications
-    .create({
+  client.verify
+    .services(service)
+    .verifications.create({
       to: to,
       channel: channel,
-      locale: locale
+      locale: locale,
     })
-    .then(verification => {
+    .then((verification) => {
       console.log(`Sent verification: '${verification.sid}'`);
       response.setStatusCode(200);
       response.setBody({
-        "success": true
+        success: true,
       });
       callback(null, response);
     })
-    .catch(error => {
+    .catch((error) => {
       console.log(error);
       response.setStatusCode(error.status);
       response.setBody({
-        "success": false,
-        "error": {
-          "message": error.message,
-          "moreInfo": error.moreInfo
-        }
+        success: false,
+        error: {
+          message: error.message,
+          moreInfo: error.moreInfo,
+        },
       });
       callback(null, response);
     });

--- a/verify/tests/start-verify.test.js
+++ b/verify/tests/start-verify.test.js
@@ -1,26 +1,28 @@
-const startVerifyFunction = require('../functions/start-verify').handler;
-const helpers = require('../../test/test-helper');
+const startVerifyFunction = require("../functions/start-verify").handler;
+const helpers = require("../../test/test-helper");
 
 const mockService = {
   verifications: {
-    create: jest.fn(() => Promise.resolve({
-      sid: "my-new-sid"
-    }))
-  }
-}
+    create: jest.fn(() =>
+      Promise.resolve({
+        sid: "my-new-sid",
+      })
+    ),
+  },
+};
 
 const mockClient = {
   verify: {
-    services: jest.fn(() => mockService)
-  }
-}
-
-const testContext = {
-  VERIFY_SERVICE_SID: 'default',
-  getTwilioClient: () => mockClient
+    services: jest.fn(() => mockService),
+  },
 };
 
-describe('verify/start-verification', () => {
+const testContext = {
+  VERIFY_SERVICE_SID: "default",
+  getTwilioClient: () => mockClient,
+};
+
+describe("verify/start-verification", () => {
   beforeAll(() => {
     helpers.setup({});
   });
@@ -28,26 +30,51 @@ describe('verify/start-verification', () => {
     helpers.teardown();
   });
 
-  test('returns an error response when required parameters are missing', done => {
+  test("returns an error response when required parameters are missing", (done) => {
     const callback = (err, result) => {
       expect(result).toBeDefined();
       expect(result._body.success).toEqual(false);
-      expect(result._body.error.message).toEqual("Missing parameter; please provide a phone number or email.");
-      expect(mockClient.verify.services).not.toHaveBeenCalledWith(testContext.VERIFY_SERVICE_SID);
+      expect(result._body.error.message).toEqual(
+        "Missing parameter; please provide a phone number or email."
+      );
+      expect(mockClient.verify.services).not.toHaveBeenCalledWith(
+        testContext.VERIFY_SERVICE_SID
+      );
       done();
     };
     const event = {};
     startVerifyFunction(testContext, event, callback);
   });
 
-  test('returns success with valid request', done => {
+  test('returns an error when "call" is the channel parameter', (done) => {
+    const callback = (err, result) => {
+      expect(result).toBeDefined();
+      expect(result._body.success).toEqual(false);
+      expect(result._body.error.message).toEqual(
+        "Calls disabled by default. Update the code in <code>start-verify.js</code> to enable."
+      );
+      expect(mockClient.verify.services).not.toHaveBeenCalledWith(
+        testContext.VERIFY_SERVICE_SID
+      );
+      done();
+    };
+    const event = {
+      to: "+17341234567",
+      channel: "call",
+    };
+    startVerifyFunction(testContext, event, callback);
+  });
+
+  test("returns success with valid request", (done) => {
     const callback = (err, result) => {
       expect(result).toBeDefined();
       expect(result._body.success).toEqual(true);
-      expect(mockClient.verify.services).toHaveBeenCalledWith(testContext.VERIFY_SERVICE_SID);
+      expect(mockClient.verify.services).toHaveBeenCalledWith(
+        testContext.VERIFY_SERVICE_SID
+      );
       done();
     };
-    const event = { "to": "+17341234567" }
+    const event = { to: "+17341234567" };
     startVerifyFunction(testContext, event, callback);
   });
 });


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

A small safety measure to help protect against [toll fraud](https://www.twilio.com/docs/verify/preventing-toll-fraud). Sorry for the larger diff, my linter finally works.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
