### PR TITLE
fix(vaccine-standby): clarify language, use context for env

### DIFF
--- a/vaccine-standby/README.md
+++ b/vaccine-standby/README.md
@@ -2,7 +2,9 @@
 
 This app is designed for public health agencies to create a COVID-19 vaccine eligibility standby list for their city or state. Residents send an SMS to a pre-configured Twilio phone number, and are asked a series of demographic questions informed by the CDC's vaccine rollout guidelines powered by a Twilio Studio Flow. Resident responses to the SMS chatbot are captured Studio Flow logs and displayed on a password protected section of the `index.html` page of this app.
 
-This data is meant to help ensure vaccinations are administered as quickly as possible as supply becomes available. With this template, your agency can create a standardized list of eligible vaccine recipients. In exchange for sharing this information, residents are instructed that they will be notified when it is their turn to receive the vaccine. The ability to send outbound notifications to those that register is out of the scope of this template.
+This data is meant to help ensure vaccinations are administered as quickly as possible as supply becomes available. With this template, your agency can create a standardized list of eligible vaccine recipients. In exchange for sharing this information, residents are instructed that they will be notified when it is their turn to receive the vaccine. This template does not currently include functionality to send notifications after registration.
+
+**Note that this app is designed for prototyping purposes only and you should<br/><a href="https://ahoy.twilio.com/vaccine-distribution-1" target="_blank">consult with a Twilio Expert</a> before publicly offering this service in a production context.**
 
 ## Pre-requisites
 

--- a/vaccine-standby/assets/index.html
+++ b/vaccine-standby/assets/index.html
@@ -13,11 +13,14 @@
     <header>
       <h1>COVID-19 Vaccine Standby List</h1>
       <img class="standby-list-diagram" src="/standby-list-diagram.png" />
+      <div id="hipaa-disclaimer" style="margin-bottom: 20px;">
+        Note that this app is designed for prototyping purposes only and you should<br/><a href="https://ahoy.twilio.com/vaccine-distribution-1" target="_blank">consult with a Twilio Expert</a> before publicly offering this service in a production context.
+      </div>
       <p>This app is designed for public health agencies to create a COVID-19 vaccine eligibility standby list for their city or state.
       Residents send an SMS to a pre-configured phone number, and are asked a series of demographic questions informed by the CDC's vaccine rollout guidelines powered by a Twilio Studio Flow.
        
       <p>This data is meant to help ensure vaccinations are administered as quickly as possible as supply becomes available. With this template, your agency can create a standardized list of eligible
-      vaccine recipients. In exchange for sharing this information, residents are notified when it is their turn to receive the vaccine.</p>
+      vaccine recipients. In exchange for sharing this information, residents are instructed that they will be notified when it is their turn to receive the vaccine. <strong>Note:</strong> This template does not currently include functionality to send notifications after registration.</p>
     </header>
     <main>
       <section>

--- a/vaccine-standby/functions/check-existing-flow.js
+++ b/vaccine-standby/functions/check-existing-flow.js
@@ -1,18 +1,7 @@
 exports.handler = async function(context, event, callback) {
 
     const client = context.getTwilioClient();
-    const path = Runtime.getFunctions()['auth'].path;
-    const { getCurrentEnvironment, getEnvironmentVariable } = require(path);
-
-    const environment = await getCurrentEnvironment(context);
-    let flowSid;
-    if (environment) {
-        const flowVar = await getEnvironmentVariable(context, environment, 'FLOW_SID');
-        flowSid = flowVar.value;
-    } else {
-        // Local development
-        flowSid = process.env.FLOW_SID;
-    }
+    const flowSid = context.FLOW_SID;
 
     client.studio.flows.list({limit: 100})
         .then(flows => {

--- a/vaccine-standby/functions/get-studio-executions.js
+++ b/vaccine-standby/functions/get-studio-executions.js
@@ -3,7 +3,7 @@ exports.handler = async function (context, event, callback) {
   // Validate token before running
   /* eslint-disable no-console */
   const path = Runtime.getFunctions()['auth'].path;
-  const { isAllowed, getCurrentEnvironment, getEnvironmentVariable } = require(path);
+  const { isAllowed } = require(path);
 
   if (!isAllowed(event.token, context)) {
     // eslint-disable-next-line no-undef
@@ -16,15 +16,7 @@ exports.handler = async function (context, event, callback) {
     return;
   }
   const client = context.getTwilioClient();
-  const environment = await getCurrentEnvironment(context);
-  let flowSid;
-  if (environment) {
-    const flowVar = await getEnvironmentVariable(context, environment, 'FLOW_SID');
-    flowSid = flowVar.value;
-  } else {
-    // Local development
-    flowSid = process.env.FLOW_SID;
-  }
+  const flowSid = context.FLOW_SID;
 
   client.studio.v1.flows(flowSid).executions.list({ limit: 100 })
     .then((executions) => {


### PR DESCRIPTION
- Add disclaimer about contacting us before running in production
- Make clear that app does not contain functionality for notifications
- Remove unnecessary use of fetching serverless environment to read `.env` variables