### PR TITLE
feat(index.html): Migrate meta-template and 5 apps

### DIFF
--- a/_helpers/meta-template/assets/index.html
+++ b/_helpers/meta-template/assets/index.html
@@ -6,6 +6,7 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <title>Get started with your Twilio Functions!</title>
 
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
         <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
         <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
         <script>

--- a/_helpers/meta-template/assets/index.html
+++ b/_helpers/meta-template/assets/index.html
@@ -70,7 +70,7 @@
                             configured to point at the following URL
                             <form>
                                 <label for="twilio-webhook">Webhook URL</label>
-                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/forward-message">
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/hello-messaging">
                             </form>
                         </li>
                     </ul>

--- a/_helpers/meta-template/assets/index.html
+++ b/_helpers/meta-template/assets/index.html
@@ -1,100 +1,84 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Get started with your Twilio Functions!</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
-    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
-    <style>
-      body {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
 
-      div[role="main"] {
-        flex: 1;
-      }
-
-      footer {
-        text-align: center;
-      }
-
-      footer p {
-        margin-bottom: 0;
-      }
-
-      #twilio-logo {
-        width: 50px;
-        height: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Welcome to your new Twilio App</h1>
-    </header>
-    <div role="main">
-      <section>
-        <h3>Get started with your app</h3>
-        <p>Now that your code is deployed, here are the last steps you need to do to finish your app.</p>
-        <ol>
-          <li>Text anything to your Twilio app</li>
-          <li>You should receive a response saying "Hello World"</li>
-        </ol>
-      </section>
-      <section>
-        <h3>Troubleshooting</h3>
-        <ul>
-          <li>Make sure the Twilio phone number you want your app has a messaging webhook configured to point at
-          </li>
-          <p>
-            <pre><code><span class="function-root"></span>/hello-messaging</code></pre>
-          </p>
-          <li>Check the
-            <code>README.md</code>
-            of your project</li>
-        </ul>
-      </section>
-    </div>
-    <footer>
-      <p>
-        <a href="https://www.twilio.com/">
-          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
-            <defs>
-              <style>
-                .cls-1 {
-                  fill: #f22f46;
-                }
-              </style>
-            </defs>
-            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
-        </a>
-      </p>
-      <p>
-        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
-      </p>
-    </footer>
-
-    <script>
-      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
-      const baseUrl = new URL(location.href);
-      baseUrl.pathname = baseUrl
-        .pathname
-        .replace(/\/index\.html$/, '');
-      delete baseUrl.hash;
-      delete baseUrl.search;
-      const fullUrl = baseUrl
-        .href
-        .substr(0, baseUrl.href.length - 1);
-      const functionRoots = document.querySelectorAll('span.function-root');
-
-      functionRoots.forEach(element => {
-        element.innerText = fullUrl
-      })
-    </script>
-  </body>
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This app will return the <a href="https://www.twilio.com/docs/sms/twiml">TwiML</a> required to
+                        respond "Hello World" to incoming SMS messages.
+                    </p>
+                    <ol class="steps">
+                        <li>Text any message to your Twilio phone number</li>
+                        <li>You should receive a response saying "Hello World"</li>
+                    </ol>
+                </section>
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a SMS webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/forward-message">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
 </html>

--- a/forward-call/assets/index.html
+++ b/forward-call/assets/index.html
@@ -6,6 +6,7 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <title>Get started with your Twilio Functions!</title>
 
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
         <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
         <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
         <script>

--- a/forward-call/assets/index.html
+++ b/forward-call/assets/index.html
@@ -1,99 +1,84 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Get started with your Twilio Functions!</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
-    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
-    <style>
-      body {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
 
-      div[role="main"] {
-        flex: 1;
-      }
-
-      footer {
-        text-align: center;
-      }
-
-      footer p {
-        margin-bottom: 0;
-      }
-
-      #twilio-logo {
-        width: 50px;
-        height: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Welcome to your new Twilio App</h1>
-    </header>
-    <div role="main">
-      <section>
-        <h3>Get started with your app</h3>
-        <p>Now that your code is deployed, here are the last steps you need to do to finish your app.</p>
-        <p>This app will return the TwiML required to forward an incoming call to a number that is set in the environment variables.</p>
-        <ol>
-          <li>Call your Twilio phone number</li>
-          <li>Receive the forwarded call to the number you configured the app with</li>
-        </ol>
-      </section>
-      <section>
-        <h3>Troubleshooting</h3>
-        <ul>
-          <li>Check the <a href="https://www.twilio.com/console/phone-numbers/incoming">phone number configuration</a> and make sure the Twilio phone number you want your app has a voice webhook configured to point at
-          <p>
-            <pre><code><span class="function-root"></span>/forward-call</code></pre>
-          </p>
-          </li>
-        </ul>
-      </section>
-      <!-- APP_INFO -->
-    </div>
-    <footer>
-      <p>
-        <a href="https://www.twilio.com/">
-          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
-            <defs>
-              <style>
-                .cls-1 {
-                  fill: #f22f46;
-                }
-              </style>
-            </defs>
-            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
-        </a>
-      </p>
-      <p>
-        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
-      </p>
-    </footer>
-
-    <script>
-      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
-      const baseUrl = new URL(location.href);
-      baseUrl.pathname = baseUrl
-        .pathname
-        .replace(/\/index\.html$/, '');
-      delete baseUrl.hash;
-      delete baseUrl.search;
-      const fullUrl = baseUrl
-        .href
-        .substr(0, baseUrl.href.length - 1);
-      const functionRoots = document.querySelectorAll('span.function-root');
-
-      functionRoots.forEach(element => {
-        element.innerText = fullUrl
-      })
-    </script>
-  </body>
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This app will return the <a href="https://www.twilio.com/docs/sms/twiml">TwiML</a> required to
+                        forward an incoming call to a number that is set in the environment variables.
+                    </p>
+                    <ol class="steps">
+                        <li>Call your Twilio phone number</li>
+                        <li>Receive the forwarded call at the number you configured the app to use</li>
+                    </ol>
+                </section>
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a voice webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/forward-call">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
 </html>

--- a/forward-message-mailgun/assets/index.html
+++ b/forward-message-mailgun/assets/index.html
@@ -6,6 +6,7 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <title>Get started with your Twilio Functions!</title>
 
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
         <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
         <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
         <script>

--- a/forward-message-mailgun/assets/index.html
+++ b/forward-message-mailgun/assets/index.html
@@ -1,127 +1,95 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Get started with your Twilio Functions!</title>
-    <link
-      rel="stylesheet"
-      href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic"
-    />
-    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css" />
-    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css" />
-    <style>
-      body {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
 
-      div[role="main"] {
-        flex: 1;
-      }
-
-      footer {
-        text-align: center;
-      }
-
-      footer p {
-        margin-bottom: 0;
-      }
-
-      #twilio-logo {
-        width: 50px;
-        height: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Welcome to your new Twilio App</h1>
-    </header>
-    <div role="main">
-      <section>
-        <h3>Get started with your app</h3>
-        <p>
-          This app forwards SMS messages sent to your Twilio phone number to the specified email
-          address using Mailgun. Follow the steps below to test your app:
-        </p>
-        <ol>
-          <li>Text your Twilio phone number with a message.</li>
-          <li>
-            You should receive an email with the contents of the SMS in the email specified in
-            <b>TO_EMAIL_ADDRESS</b> env variable
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h3>Troubleshooting</h3>
-        <ul>
-          <li>
-            Check the
-            <a href="https://www.twilio.com/console/phone-numbers/incoming"
-              >phone number configuration</a
-            >
-            and make sure the Twilio phone number you want your app has an SMS webhook configured to
-            point at
-          </li>
-          <li>
-            This function expects four environment variables to be set. You should configure these
-            in your
-            <a
-              href="https://www.twilio.com/console/runtime/functions/configure"
-              target="_blank"
-              rel="noopener"
-              >functions configuration page</a
-            >
-          </li>
-        </ul>
-      </section>
-    </div>
-    <footer>
-      <p>
-        <a href="https://www.twilio.com/">
-          <svg
-            id="twilio-logo"
-            data-name="Layer 1"
-            xmlns="http://www.w3.org/2000/svg"
-            viewbox="0 0 60 60"
-          >
-            <defs>
-              <style>
-                .cls-1 {
-                  fill: #f22f46;
-                }
-              </style>
-            </defs>
-            <title>Twilio Logo</title>
-            <path
-              class="cls-1"
-              d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"
-            />
-          </svg>
-        </a>
-      </p>
-      <p>
-        <a href="https://www.twilio.com/code-exchange"
-          >Learn about other things you can build with Twilio</a
-        >
-      </p>
-    </footer>
-
-    <script>
-      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
-      const baseUrl = new URL(location.href);
-      baseUrl.pathname = baseUrl.pathname.replace(/\/index\.html$/, "");
-      delete baseUrl.hash;
-      delete baseUrl.search;
-      const fullUrl = baseUrl.href.substr(0, baseUrl.href.length - 1);
-      const functionRoots = document.querySelectorAll("span.function-root");
-
-      functionRoots.forEach((element) => {
-        element.innerText = fullUrl;
-      });
-    </script>
-  </body>
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This app forwards SMS messages sent to your Twilio phone number to the specified email
+                        address using <a href="https://www.mailgun.com/">Mailgun</a>.
+                    </p>
+                    <ol class="steps">
+                        <li>Text any message to your Twilio phone number</li>
+                        <li>
+                            You should receive an email with the contents of the SMS, sent to the address
+                            specified in the <code>TO_EMAIL_ADDRESS</code> environment variable.
+                        </li>
+                    </ol>
+                </section>
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a SMS webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/forward-message">
+                            </form>
+                        </li>
+                        <li>
+                            This function expects four environment variables to be set. You should
+                            configure these in your
+                            <a
+                                href="https://www.twilio.com/console/runtime/functions/configure"
+                                target="_blank"
+                                rel="noopener">functions configuration page</a>.
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
 </html>

--- a/forward-message-mailgun/assets/index.html
+++ b/forward-message-mailgun/assets/index.html
@@ -73,7 +73,7 @@
                             configured to point at the following URL
                             <form>
                                 <label for="twilio-webhook">Webhook URL</label>
-                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/forward-message">
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/forward-message-mailgun">
                             </form>
                         </li>
                         <li>

--- a/forward-message-multiple/assets/index.html
+++ b/forward-message-multiple/assets/index.html
@@ -6,6 +6,7 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <title>Get started with your Twilio Functions!</title>
 
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
         <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
         <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
         <script>

--- a/forward-message-multiple/assets/index.html
+++ b/forward-message-multiple/assets/index.html
@@ -1,99 +1,85 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Get started with your Twilio Functions!</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
-    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
-    <style>
-      body {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
 
-      div[role="main"] {
-        flex: 1;
-      }
-
-      footer {
-        text-align: center;
-      }
-
-      footer p {
-        margin-bottom: 0;
-      }
-
-      #twilio-logo {
-        width: 50px;
-        height: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Welcome to your new Twilio App</h1>
-    </header>
-    <div role="main">
-      <section>
-        <h3>Get started with your app</h3>
-        <p>Now that your code is deployed, here are the last steps you need to do to finish your app.</p>
-        <p>This app will return the TwiML required to forward an incoming SMS message to each number in the comma separated list of numbers set in the environment variables.</p>
-        <ol>
-          <li>Text any message to your Twilio phone number</li>
-          <li>Every phone number you specified should receive the response message from Twilio</li>
-        </ol>
-      </section>
-      <section>
-        <h3>Troubleshooting</h3>
-        <ul>
-          <li>Check the <a href="https://www.twilio.com/console/phone-numbers/incoming">phone number configuration</a> and make sure the Twilio phone number you want your app has a SMS webhook configured to point at
-          <p>
-            <pre><code><span class="function-root"></span>/forward-message-multiple</code></pre>
-          </p>
-          </li>
-        </ul>
-      </section>
-      <!-- APP_INFO -->
-    </div>
-    <footer>
-      <p>
-        <a href="https://www.twilio.com/">
-          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
-            <defs>
-              <style>
-                .cls-1 {
-                  fill: #f22f46;
-                }
-              </style>
-            </defs>
-            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
-        </a>
-      </p>
-      <p>
-        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
-      </p>
-    </footer>
-
-    <script>
-      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
-      const baseUrl = new URL(location.href);
-      baseUrl.pathname = baseUrl
-        .pathname
-        .replace(/\/index\.html$/, '');
-      delete baseUrl.hash;
-      delete baseUrl.search;
-      const fullUrl = baseUrl
-        .href
-        .substr(0, baseUrl.href.length - 1);
-      const functionRoots = document.querySelectorAll('span.function-root');
-
-      functionRoots.forEach(element => {
-        element.innerText = fullUrl
-      })
-    </script>
-  </body>
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This app will return the <a href="https://www.twilio.com/docs/sms/twiml">TwiML</a> required
+                        to forward an incoming SMS message to each number in the comma separated list of numbers set in the environment
+                        variables.
+                    </p>
+                    <ol class="steps">
+                        <li>Text any message to your Twilio phone number</li>
+                        <li>Every phone number you specified should receive the response message from Twilio</li>
+                    </ol>
+                </section>
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a SMS webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/forward-message">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
 </html>

--- a/forward-message-multiple/assets/index.html
+++ b/forward-message-multiple/assets/index.html
@@ -71,7 +71,7 @@
                             configured to point at the following URL
                             <form>
                                 <label for="twilio-webhook">Webhook URL</label>
-                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/forward-message">
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/forward-message-multiple">
                             </form>
                         </li>
                     </ul>

--- a/forward-message-sendgrid/assets/index.html
+++ b/forward-message-sendgrid/assets/index.html
@@ -1,98 +1,87 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Get started with your Twilio Functions!</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
-    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
-    <style>
-      body {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
 
-      div[role="main"] {
-        flex: 1;
-      }
-
-      footer {
-        text-align: center;
-      }
-
-      footer p {
-        margin-bottom: 0;
-      }
-
-      #twilio-logo {
-        width: 50px;
-        height: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Welcome to your new Twilio App</h1>
-    </header>
-    <div role="main">
-      <section>
-        <h3>Get started with your app</h3>
-        <p>This app forwards SMS messages sent to your Twilio phone number to the specified email address using SendGrid. Follow the steps below to test your app:</p>
-        <ol>
-          <li>Text your Twilio phone number with a message.</li>
-          <li>You should receive an email with the contents of the SMS in the email specified in <b>TO_EMAIL_ADDRESS</b></li>
-        </ol>
-      </section>
-      <section>
-        <h3>Troubleshooting</h3>
-        <ul>
-          <li>Check the <a href="https://www.twilio.com/console/phone-numbers/incoming">phone number configuration</a> and make sure the Twilio phone number you want your app has an SMS webhook configured to point at
-            <p>
-              <pre><code><span class="function-root"></span>/forward-message-sendgrid</code></pre>
-            </p>
-          </li>
-        </ul>
-      </section>
-      <!-- APP_INFO -->
-    </div>
-    <footer>
-      <p>
-        <a href="https://www.twilio.com/">
-          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
-            <defs>
-              <style>
-                .cls-1 {
-                  fill: #f22f46;
-                }
-              </style>
-            </defs>
-            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
-        </a>
-      </p>
-      <p>
-        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
-      </p>
-    </footer>
-
-    <script>
-      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
-      const baseUrl = new URL(location.href);
-      baseUrl.pathname = baseUrl
-        .pathname
-        .replace(/\/index\.html$/, '');
-      delete baseUrl.hash;
-      delete baseUrl.search;
-      const fullUrl = baseUrl
-        .href
-        .substr(0, baseUrl.href.length - 1);
-      const functionRoots = document.querySelectorAll('span.function-root');
-
-      functionRoots.forEach(element => {
-        element.innerText = fullUrl
-      })
-    </script>
-  </body>
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This app forwards SMS messages sent to your Twilio phone number to the specified email
+                        address using <a href="https://sendgrid.com/">SendGrid</a>.
+                    </p>
+                    <ol class="steps">
+                        <li>Text any message to your Twilio phone number</li>
+                        <li>
+                            You should receive an email with the contents of the SMS in the email specified in
+                            <code>TO_EMAIL_ADDRESS</code>
+                        </li>
+                    </ol>
+                </section>
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a SMS webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/forward-message-sendgrid">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
 </html>

--- a/forward-message-sendgrid/assets/index.html
+++ b/forward-message-sendgrid/assets/index.html
@@ -6,6 +6,7 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <title>Get started with your Twilio Functions!</title>
 
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
         <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
         <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
         <script>

--- a/forward-message-sparkpost/assets/index.html
+++ b/forward-message-sparkpost/assets/index.html
@@ -6,6 +6,7 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <title>Get started with your Twilio Functions!</title>
 
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
         <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
         <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
         <script>

--- a/forward-message-sparkpost/assets/index.html
+++ b/forward-message-sparkpost/assets/index.html
@@ -1,98 +1,87 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Get started with your Twilio Functions!</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
-    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
-    <style>
-      body {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
 
-      div[role="main"] {
-        flex: 1;
-      }
-
-      footer {
-        text-align: center;
-      }
-
-      footer p {
-        margin-bottom: 0;
-      }
-
-      #twilio-logo {
-        width: 50px;
-        height: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Welcome to your new Twilio App</h1>
-    </header>
-    <div role="main">
-      <section>
-        <h3>Get started with your app</h3>
-        <p>This app forwards SMS messages sent to your Twilio phone number to the specified email address using SparkPost. Follow the steps below to test your app:</p>
-        <ol>
-          <li>Text your Twilio phone number with a message.</li>
-          <li>You should receive an email with the contents of the SMS in the email specified in <b>TO_EMAIL_ADDRESS</b></li>
-        </ol>
-      </section>
-      <section>
-        <h3>Troubleshooting</h3>
-        <ul>
-          <li>Check the <a href="https://www.twilio.com/console/phone-numbers/incoming">phone number configuration</a> and make sure the Twilio phone number you want your app has an SMS webhook configured to point at
-            <p>
-              <pre><code><span class="function-root"></span>/forward-message-sparkpost</code></pre>
-            </p>
-          </li>
-        </ul>
-      </section>
-      <!-- APP_INFO -->
-    </div>
-    <footer>
-      <p>
-        <a href="https://www.twilio.com/">
-          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
-            <defs>
-              <style>
-                .cls-1 {
-                  fill: #f22f46;
-                }
-              </style>
-            </defs>
-            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
-        </a>
-      </p>
-      <p>
-        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
-      </p>
-    </footer>
-
-    <script>
-      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
-      const baseUrl = new URL(location.href);
-      baseUrl.pathname = baseUrl
-        .pathname
-        .replace(/\/index\.html$/, '');
-      delete baseUrl.hash;
-      delete baseUrl.search;
-      const fullUrl = baseUrl
-        .href
-        .substr(0, baseUrl.href.length - 1);
-      const functionRoots = document.querySelectorAll('span.function-root');
-
-      functionRoots.forEach(element => {
-        element.innerText = fullUrl
-      })
-    </script>
-  </body>
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This app forwards SMS messages sent to your Twilio phone number to the specified email address
+                        using <a href="https://www.sparkpost.com/">SparkPost</a>.
+                    </p>
+                    <ol class="steps">
+                        <li>Text any message to your Twilio phone number</li>
+                        <li>
+                            You should receive an email with the contents of the SMS at the email address specified in
+                            <code>TO_EMAIL_ADDRESS</code>
+                        </li>
+                    </ol>
+                </section>
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a SMS webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/forward-message-sparkpost">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
 </html>

--- a/forward-message/assets/index.html
+++ b/forward-message/assets/index.html
@@ -6,6 +6,7 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <title>Get started with your Twilio Functions!</title>
 
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
         <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
         <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
         <script>


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description
Updates `meta-template` (which `npm run new-template` copies as the basis of new apps) and 5 apps to use the redesigned `index.html`. The apps updated are:

- `forward-message-mailgun`
- `forward-message-multiple`
- `forward-message-sendgrid`
- `forward-message-sparkpost`
- `forward-call`

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
