### PR TITLE
feat(index.html) Second batch of migrations

### DIFF
--- a/conference-caller-gated/assets/index.html
+++ b/conference-caller-gated/assets/index.html
@@ -1,99 +1,98 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Get started with your Twilio Functions!</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
-    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
-    <style>
-      body {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
 
-      div[role="main"] {
-        flex: 1;
-      }
-
-      footer {
-        text-align: center;
-      }
-
-      footer p {
-        margin-bottom: 0;
-      }
-
-      #twilio-logo {
-        width: 50px;
-        height: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Welcome to your new Twilio App</h1>
-    </header>
-    <div role="main">
-      <section>
-        <h3>Get started with your app</h3>
-        <p>Now that your code is deployed, here are the last steps you need to do to finish your app.</p>
-        <p>This app only allows certain numbers to join the conference call. This won't do any verification that the caller is not spoofing the number. For that check out the <a href="https://www.twilio.com/code-exchange/conference-verification">Conference Line with Phone Verification</a></p>
-        <ol>
-          <li>Call your Twilio phone number from the phone number entered for <b>MODERATOR_PHONE_NUMBER</b></li>
-          <li>Call your Twilio phone number from another number used for <b>VALID_PARTICIPANTS</b> to begin the conference call</li>
-        </ol>
-      </section>
-      <section>
-        <h3>Troubleshooting</h3>
-        <ul>
-          <li>Check the <a href="https://www.twilio.com/console/phone-numbers/incoming">phone number configuration</a> and make sure the Twilio phone number you want your app has a voice webhook configured to point at
-          <p>
-            <pre><code><span class="function-root"></span>/gated-conference</code></pre>
-          </p>
-          </li>
-        </ul>
-      </section>
-      <!-- APP_INFO -->
-    </div>
-    <footer>
-      <p>
-        <a href="https://www.twilio.com/">
-          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
-            <defs>
-              <style>
-                .cls-1 {
-                  fill: #f22f46;
-                }
-              </style>
-            </defs>
-            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
-        </a>
-      </p>
-      <p>
-        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
-      </p>
-    </footer>
-
-    <script>
-      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
-      const baseUrl = new URL(location.href);
-      baseUrl.pathname = baseUrl
-        .pathname
-        .replace(/\/index\.html$/, '');
-      delete baseUrl.hash;
-      delete baseUrl.search;
-      const fullUrl = baseUrl
-        .href
-        .substr(0, baseUrl.href.length - 1);
-      const functionRoots = document.querySelectorAll('span.function-root');
-
-      functionRoots.forEach(element => {
-        element.innerText = fullUrl
-      })
-    </script>
-  </body>
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This app only allows certain numbers to join the conference call. This won't do any verification
+                        that the caller is not spoofing the number. For that, check out the
+                        <a href="https://www.twilio.com/code-exchange/conference-verification"
+                           target="_blank"
+                           rel="noopener">
+                            Conference Line with Phone Verification
+                        </a> app.
+                    </p>
+                    <ol class="steps">
+                        <li>
+                            Call your Twilio phone number from the phone number entered for
+                            <code>MODERATOR_PHONE_NUMBER</code>
+                        </li>
+                        <li>Call your Twilio phone number from another number used for
+                            <code>VALID_PARTICIPANTS</code>
+                            to begin the conference call
+                        </li>
+                    </ol>
+                </section>
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                               target="_blank"
+                               rel="noopener">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a voice webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/gated-conference">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
 </html>

--- a/conference-pin/assets/index.html
+++ b/conference-pin/assets/index.html
@@ -1,99 +1,90 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Get started with your Twilio Functions!</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
-    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
-    <style>
-      body {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
 
-      div[role="main"] {
-        flex: 1;
-      }
-
-      footer {
-        text-align: center;
-      }
-
-      footer p {
-        margin-bottom: 0;
-      }
-
-      #twilio-logo {
-        width: 50px;
-        height: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Welcome to your new Twilio App</h1>
-    </header>
-    <div role="main">
-      <section>
-        <h3>Get started with your app</h3>
-        <p>Now that your code is deployed, here are the last steps you need to do to finish your app.</p>
-        <p>This app prompts callers for a PIN before granting them access to a conference call</p>
-        <ol>
-          <li>Call your Twilio phone number and enter the pin you set for <b>CONFERENCE_PIN</b></li>
-          <li>Call your Twilio phone number from another phone number to begin the conference call</li>
-        </ol>
-      </section>
-      <section>
-        <h3>Troubleshooting</h3>
-        <ul>
-          <li>Check the <a href="https://www.twilio.com/console/phone-numbers/incoming">phone number configuration</a> and make sure the Twilio phone number you want your app has a voice webhook configured to point at
-          <p>
-            <pre><code><span class="function-root"></span>/conference-with-pin</code></pre>
-          </p>
-          </li>
-        </ul>
-      </section>
-      <!-- APP_INFO -->
-    </div>
-    <footer>
-      <p>
-        <a href="https://www.twilio.com/">
-          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
-            <defs>
-              <style>
-                .cls-1 {
-                  fill: #f22f46;
-                }
-              </style>
-            </defs>
-            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
-        </a>
-      </p>
-      <p>
-        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
-      </p>
-    </footer>
-
-    <script>
-      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
-      const baseUrl = new URL(location.href);
-      baseUrl.pathname = baseUrl
-        .pathname
-        .replace(/\/index\.html$/, '');
-      delete baseUrl.hash;
-      delete baseUrl.search;
-      const fullUrl = baseUrl
-        .href
-        .substr(0, baseUrl.href.length - 1);
-      const functionRoots = document.querySelectorAll('span.function-root');
-
-      functionRoots.forEach(element => {
-        element.innerText = fullUrl
-      })
-    </script>
-  </body>
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This app prompts callers for a PIN before granting them access to a
+                        conference call.
+                    </p>
+                    <ol class="steps">
+                        <li>
+                            Call your Twilio phone number and enter the pin you set for
+                            <code>CONFERENCE_PIN</code>
+                        </li>
+                        <li>Call your Twilio phone number from another phone number to begin the conference call</li>
+                    </ol>
+                </section>
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                               target="_blank"
+                               rel="noopener">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a voice webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/conference-with-pin">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
 </html>

--- a/conference-verify/assets/index.html
+++ b/conference-verify/assets/index.html
@@ -1,100 +1,99 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Get started with your Twilio Functions!</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
-    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
-    <style>
-      body {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
 
-      div[role="main"] {
-        flex: 1;
-      }
-
-      footer {
-        text-align: center;
-      }
-
-      footer p {
-        margin-bottom: 0;
-      }
-
-      #twilio-logo {
-        width: 50px;
-        height: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Welcome to your new Twilio App</h1>
-    </header>
-    <div role="main">
-      <section>
-        <h3>Get started with your app</h3>
-        <p>Now that your code is deployed, here are the last steps you need to do to finish your app.</p>
-        <p>This app create a conference line that verifies the phone numbers of participants before joining them into a call. It will first verify that the number is on a list of valid numbers and then use <a href="https://www.twilio.com/docs/verify/api">Twilio Verify</a> to verify they are not spoofing their number by sending them a code they have to enter.</p>
-        <ol>
-          <li>Call your Twilio phone number from the phone number entered for <b>MODERATOR_PHONE_NUMBER</b></li>
-          <li>Call your Twilio phone number from another number used for <b>VALID_PARTICIPANTS</b></li>
-          <li>Follow the propmts to verify the participant</li>
-        </ol>
-      </section>
-      <section>
-        <h3>Troubleshooting</h3>
-        <ul>
-          <li>Check the <a href="https://www.twilio.com/console/phone-numbers/incoming">phone number configuration</a> and make sure the Twilio phone number you want your app has a voice webhook configured to point at
-          <p>
-            <pre><code><span class="function-root"></span>/verify-conference</code></pre>
-          </p>
-          </li>
-        </ul>
-      </section>
-      <!-- APP_INFO -->
-    </div>
-    <footer>
-      <p>
-        <a href="https://www.twilio.com/">
-          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
-            <defs>
-              <style>
-                .cls-1 {
-                  fill: #f22f46;
-                }
-              </style>
-            </defs>
-            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
-        </a>
-      </p>
-      <p>
-        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
-      </p>
-    </footer>
-
-    <script>
-      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
-      const baseUrl = new URL(location.href);
-      baseUrl.pathname = baseUrl
-        .pathname
-        .replace(/\/index\.html$/, '');
-      delete baseUrl.hash;
-      delete baseUrl.search;
-      const fullUrl = baseUrl
-        .href
-        .substr(0, baseUrl.href.length - 1);
-      const functionRoots = document.querySelectorAll('span.function-root');
-
-      functionRoots.forEach(element => {
-        element.innerText = fullUrl
-      })
-    </script>
-  </body>
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This app creates a conference line that verifies the phone numbers of participants
+                        before joining them into a call. It will first verify that the number is on a list of
+                        valid numbers and then use
+                        <a href="https://www.twilio.com/docs/verify/api" target="_blank" rel="noopener">
+                            Twilio Verify
+                        </a>
+                        to verify they are not spoofing their number by sending them a code they have to enter.
+                    </p>
+                    <ol class="steps">
+                        <li>
+                            Call your Twilio phone number from the phone number entered for
+                            <code>MODERATOR_PHONE_NUMBER</code>
+                        </li>
+                        <li>
+                            Call your Twilio phone number from another number used for
+                            <code>VALID_PARTICIPANTS</code>
+                        </li>
+                        <li>Follow the prompts to verify the participant</li>
+                    </ol>
+                </section>
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                               target="_blank"
+                               rel="noopener">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a voice webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/verify-conference">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
 </html>

--- a/conference/assets/index.html
+++ b/conference/assets/index.html
@@ -1,99 +1,91 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Get started with your Twilio Functions!</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
-    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
-    <style>
-      body {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
 
-      div[role="main"] {
-        flex: 1;
-      }
-
-      footer {
-        text-align: center;
-      }
-
-      footer p {
-        margin-bottom: 0;
-      }
-
-      #twilio-logo {
-        width: 50px;
-        height: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Welcome to your new Twilio App</h1>
-    </header>
-    <div role="main">
-      <section>
-        <h3>Get started with your app</h3>
-        <p>Now that your code is deployed, here are the last steps you need to do to finish your app.</p>
-        <p>This app  will return the TwiML required to put a call into a conference. The conference is called "Snowy Owl" by default.</p>
-        <ol>
-          <li>Call your Twilio phone number</li>
-          <li>Call your Twilio phone number from another phone number to begin the conference call</li>
-        </ol>
-      </section>
-      <section>
-        <h3>Troubleshooting</h3>
-        <ul>
-          <li>Check the <a href="https://www.twilio.com/console/phone-numbers/incoming">phone number configuration</a> and make sure the Twilio phone number you want your app has a voice webhook configured to point at
-          <p>
-            <pre><code><span class="function-root"></span>/conference</code></pre>
-          </p>
-          </li>
-        </ul>
-      </section>
-      <!-- APP_INFO -->
-    </div>
-    <footer>
-      <p>
-        <a href="https://www.twilio.com/">
-          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
-            <defs>
-              <style>
-                .cls-1 {
-                  fill: #f22f46;
-                }
-              </style>
-            </defs>
-            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
-        </a>
-      </p>
-      <p>
-        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
-      </p>
-    </footer>
-
-    <script>
-      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
-      const baseUrl = new URL(location.href);
-      baseUrl.pathname = baseUrl
-        .pathname
-        .replace(/\/index\.html$/, '');
-      delete baseUrl.hash;
-      delete baseUrl.search;
-      const fullUrl = baseUrl
-        .href
-        .substr(0, baseUrl.href.length - 1);
-      const functionRoots = document.querySelectorAll('span.function-root');
-
-      functionRoots.forEach(element => {
-        element.innerText = fullUrl
-      })
-    </script>
-  </body>
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                  </p>
+                  <p>
+                        This app will return the
+                        <a href="https://www.twilio.com/docs/sms/twiml" target="_blank" rel="noopener">TwiML</a>
+                        required to put a call into a conference. The conference is called "Snowy Owl" by default.
+                    </p>
+                    <ol class="steps">
+                        <li>Call your Twilio phone number</li>
+                        <li>
+                            Call your Twilio phone number from another phone number to begin the
+                            conference call
+                        </li>
+                    </ol>
+                </section>
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                               target="_blank"
+                               rel="noopener">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a voice webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/conference">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
 </html>


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description
This PR migrates 4 apps to use the redesigned `index.html`:

- `conference`
- `conference-verify`
- `conference-pin`
- `conference-caller-gated`

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
