### PR TITLE
feat(index.html): Migrate third batch of apps

### DIFF
--- a/airtable/assets/index.html
+++ b/airtable/assets/index.html
@@ -58,7 +58,9 @@
                             number should now be input into the table
                         </li>
                         <li>
-                            <a href="/broadcast-sms">Click here to test the broadcast feature</a>.
+                            <a href="/broadcast-sms" target="_blank">
+                                Click here to test the broadcast feature
+                            </a>.
                             All numbers that are in Airtable should receive a text
                         </li>
                     </ol>

--- a/airtable/assets/index.html
+++ b/airtable/assets/index.html
@@ -1,99 +1,95 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Get started with your Twilio Functions!</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
-    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
-    <style>
-      body {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
 
-      div[role="main"] {
-        flex: 1;
-      }
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This app automatically adds people who text your phone number into the specified table in
+                        <a href="https://airtable.com/" target="_blank" rel="noopener">Airtable</a>.
+                    </p>
+                    <ol class="steps">
+                        <li>Text your Twilio phone number with a message</li>
+                        <li>
+                            Go to the specified table in Airtable and refresh it. Your message and phone
+                            number should now be input into the table
+                        </li>
+                        <li>
+                            <a href="/broadcast-sms">Click here to test the broadcast feature</a>.
+                            All numbers that are in Airtable should receive a text
+                        </li>
+                    </ol>
+                </section>
 
-      footer {
-        text-align: center;
-      }
-
-      footer p {
-        margin-bottom: 0;
-      }
-
-      #twilio-logo {
-        width: 50px;
-        height: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Welcome to your new Twilio App</h1>
-    </header>
-    <div role="main">
-      <section>
-        <h3>Get started with your app</h3>
-        <p>This app automatically adds people who text in to your phone number into the specified table in Airtable. Follow the steps below to test your app:</p>
-        <ol>
-          <li>Text your Twilio phone number with a message.</li>
-          <li>Go to the specified table in Airtable and refresh it. Your message and phone number should now be input into the table.</li>
-          <li><a href="/broadcast-sms">Click here to test the broadcast feature</a>. All numbers that are in Airtable should receive a text.</li>
-        </ol>
-      </section>
-      <section>
-        <h3>Troubleshooting</h3>
-        <ul>
-          <li>Check the <a href="https://www.twilio.com/console/phone-numbers/incoming">phone number configuration</a> and make sure the Twilio phone number you want your app has an SMS webhook configured to point at
-            <p>
-              <pre><code><span class="function-root"></span>/save-sms</code></pre>
-            </p>
-          </li>
-        </ul>
-      </section>
-      <!-- APP_INFO -->
-    </div>
-    <footer>
-      <p>
-        <a href="https://www.twilio.com/">
-          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
-            <defs>
-              <style>
-                .cls-1 {
-                  fill: #f22f46;
-                }
-              </style>
-            </defs>
-            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
-        </a>
-      </p>
-      <p>
-        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
-      </p>
-    </footer>
-
-    <script>
-      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
-      const baseUrl = new URL(location.href);
-      baseUrl.pathname = baseUrl
-        .pathname
-        .replace(/\/index\.html$/, '');
-      delete baseUrl.hash;
-      delete baseUrl.search;
-      const fullUrl = baseUrl
-        .href
-        .substr(0, baseUrl.href.length - 1);
-      const functionRoots = document.querySelectorAll('span.function-root');
-
-      functionRoots.forEach(element => {
-        element.innerText = fullUrl
-      })
-    </script>
-  </body>
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                               target="_blank"
+                               rel="noopener">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a SMS webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/save-sms">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
 </html>

--- a/sms-broadcast/assets/index.html
+++ b/sms-broadcast/assets/index.html
@@ -1,108 +1,102 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Get started with your Twilio Functions!</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
-    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
-    <style>
-      body {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
 
-      div[role="main"] {
-        flex: 1;
-      }
-
-      footer {
-        text-align: center;
-      }
-
-      footer p {
-        margin-bottom: 0;
-      }
-
-      #twilio-logo {
-        width: 50px;
-        height: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Welcome to your new Twilio App</h1>
-    </header>
-    <div role="main">
-      <section>
-        <h3>Get started with your app</h3>
-        <p>Now that your code is deployed, here are the last steps you need to do to finish your app.</p>
-        <ol>
-          <li>Text anything to your Twilio app</li>
-          <li>You should receive a response saying "Hello! Text "subscribe" to receive updates, "stop" to stop getting messages, and "start" to receive them again."</li>
-          <li>Text "subscribe" to your Twilio app</li>
-          <li>You will be subscribed to future broadcasts and receive a response saying "Thanks! You have been subscribed for updates."</li>
-        </ol>
-        <p>From an admin phone number.</p>
-        <ol>
-          <li>Text "broadcast &lt;your message here&gt;"</li>
-          <li>The message will be sent out to all the subscribers.</li>
-          <li>You will receive a response saying "Boom! Message broadcast to all subscribers."</li>
-        </ol>
-      </section>
-      <section>
-        <h3>Troubleshooting</h3>
-        <ul>
-          <li>Make sure you have set up the Notify Service and Messaging Service correctly</li>
-          <li>Make sure that the Messaging Service is setup to handle incoming messages and the webhook is configured to point at:</li>
-          <p>
-            <pre><code><span class="function-root"></span>/broadcast</code></pre>
-          </p>
-          <li>Check the
-            <code>README.md</code>
-            of your project</li>
-        </ul>
-      </section>
-    </div>
-    <footer>
-      <p>
-        <a href="https://www.twilio.com/">
-          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
-            <defs>
-              <style>
-                .cls-1 {
-                  fill: #f22f46;
-                }
-              </style>
-            </defs>
-            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
-        </a>
-      </p>
-      <p>
-        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
-      </p>
-    </footer>
-
-    <script>
-      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
-      const baseUrl = new URL(location.href);
-      baseUrl.pathname = baseUrl
-        .pathname
-        .replace(/\/index\.html$/, '');
-      delete baseUrl.hash;
-      delete baseUrl.search;
-      const fullUrl = baseUrl
-        .href
-        .substr(0, baseUrl.href.length - 1);
-      const functionRoots = document.querySelectorAll('span.function-root');
-
-      functionRoots.forEach(element => {
-        element.innerText = fullUrl
-      })
-    </script>
-  </body>
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>This app allows you to broadcast SMS messages to large numbers of people.</p>
+                    <ol class="steps">
+                        <li>Text anything to your Twilio phone number</li>
+                        <li>
+                            You should receive a response saying "Hello! Text "subscribe" to receive updates,
+                            "stop" to stop getting messages, and "start" to receive them again."
+                        </li>
+                        <li>Reply back with "subscribe" to your Twilio phone number</li>
+                        <li>
+                            You will be subscribed to future broadcasts and receive a response saying "Thanks!
+                            You have been subscribed for updates."
+                        </li>
+                        <li>
+                            From a phone number you have allowed to trigger a broadcast, text
+                            "broadcast &lt;your message here&gt;" to your Twilio phone number
+                        </li>
+                        <li>
+                            The message will be sent out to all subscribers, and you should receive it on the
+                            phone number you used to subscribe
+                        </li>
+                    </ol>
+                </section>
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                               target="_blank"
+                               rel="noopener">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a SMS webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/broadcast">
+                            </form>
+                        </li>
+                        <li><p>Make sure you have set up the Notify Service and Messaging Service correctly.</p></li>
+                        <li><p>Ensure that the Messaging Service is set up to handle incoming messages.</p></li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
 </html>

--- a/sms-broadcast/assets/index.html
+++ b/sms-broadcast/assets/index.html
@@ -60,8 +60,8 @@
                             You have been subscribed for updates."
                         </li>
                         <li>
-                            From the phone number that you configured to trigger a broadcast, text any message
-                            to your Twilio phone number
+                            From the phone number that you configured to trigger a broadcast, text
+                            "broadcast &lt;your message here&gt;" to your Twilio phone number
                         </li>
                         <li>
                             The message will be sent out to all subscribers, and you should receive it on the
@@ -91,6 +91,13 @@
                         </li>
                         <li><p>Make sure you have set up the Notify Service and Messaging Service correctly.</p></li>
                         <li><p>Ensure that the Messaging Service is set up to handle incoming messages.</p></li>
+                        <li>
+                            <p>
+                                If you cannot send broadcasts, make sure your message starts with the "broadcast"
+                                command, and that you are messaging your Twilio phone number from the phone number
+                                you have configured to be able to send broadcasts.
+                            </p>
+                        </li>
                     </ul>
                 </section>
             </div>

--- a/sms-broadcast/assets/index.html
+++ b/sms-broadcast/assets/index.html
@@ -60,8 +60,8 @@
                             You have been subscribed for updates."
                         </li>
                         <li>
-                            From a phone number you have allowed to trigger a broadcast, text
-                            "broadcast &lt;your message here&gt;" to your Twilio phone number
+                            From the phone number that you configured to trigger a broadcast, text any message
+                            to your Twilio phone number
                         </li>
                         <li>
                             The message will be sent out to all subscribers, and you should receive it on the

--- a/stripe-payment-link-sms/assets/index.html
+++ b/stripe-payment-link-sms/assets/index.html
@@ -1,100 +1,126 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Get started with your Twilio Functions!</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
-    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
-    <style>
-      body {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
 
-      div[role="main"] {
-        flex: 1;
-      }
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+        <style>
+            ol.steps > li > form {
+                padding-left: 2rem;
+            }
+        </style>
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This app shows you how to create an invoice in Stripe based on an SMS
+                        prompt (in this case <code>DONATE &lt;AMOUNT&gt;</code>). Once the invoice
+                        is finalized, it will reply with a payment link.
+                    </p>
+                    <ol class="steps">
+                        <li>
+                            Before you can test your app, you need to add a
+                            <a href="https://dashboard.stripe.com/webhooks"
+                               target="_blank"
+                               rel="noopener">
+                                Stripe Webhook
+                            </a>
+                            and set it to point at
+                            <form>
+                                <label for="twilio-webhook">Stripe Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/send-invoice-sms">
+                            </form>
+                        </li>
+                        <li>Select "All Events" and save the webhook</li>
+                        <li>
+                            To test the customer initiated scenario of this app, text
+                            <code>DONATE 10</code> to your Twilio phone number. You should receive a
+                            Stripe invoice link to your phone
+                        </li>
+                        <li>
+                            To test the Merchant initiated flow, you need to create an invoice in the
+                            Stripe Dashbboard. Follow this
+                            <a href="https://stripe.com/docs/billing/invoices/create#without-code"
+                               target="_blank"
+                               rel="noopener">
+                                guide
+                            </a>
+                            or this <a href="https://youtu.be/YftvRXupgpw"
+                                       target="_blank"
+                                       rel="noopener">
+                                video
+                            </a>. Make sure to set
+                            a phone number when entering the customer details.
+                        </li>
+                    </ol>
+                </section>
 
-      footer {
-        text-align: center;
-      }
-
-      footer p {
-        margin-bottom: 0;
-      }
-
-      #twilio-logo {
-        width: 50px;
-        height: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Welcome to your new Twilio App</h1>
-    </header>
-    <div role="main">
-      <section>
-        <h3>Get started with your app</h3>
-        <p>This app shows you how to create an invoice in Stripe based on an SMS prompt (in this case <code>DONATE &lt;AMOUNT&gt;</code>). Once the invoice is finalized, it will reply with a payment link.</p>
-        <ol>
-          <li>Before you can test your app, you need to add a <a href="https://dashboard.stripe.com/webhooks"> Stripe Webhook</a> and set it to <code><span class="function-root"></span>/send-invoice-sms</code></li>
-          <li>Select "All Events" and save the webhook.</li>
-          <li>To test the customer initiated scenario of this app, text <code>DONATE 10</code> to your Twilio phone number. You should receive a Stripe invoice link to your phone.</li>
-          <li>To test the Merchant initiated flow, you need to create an invoice in the Stripe Dashbboard. Follow this <a href="https://stripe.com/docs/billing/invoices/create#without-code">guide</a> or this <a href="https://youtu.be/YftvRXupgpw">video</a>. Make sure to set a phone number when entering the customer details.</li>
-        </ol>
-      </section>
-      <section>
-        <h3>Troubleshooting</h3>
-        <ul>
-          <li>Check the <a href="https://www.twilio.com/console/phone-numbers/incoming">phone number configuration</a> and make sure the Twilio phone number you want your app has an SMS webhook configured to point at
-            <p>
-              <pre><code><span class="function-root"></span>/create-invoice</code></pre>
-            </p>
-          </li>
-        </ul>
-      </section>
-      <!-- APP_INFO -->
-    </div>
-    <footer>
-      <p>
-        <a href="https://www.twilio.com/">
-          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
-            <defs>
-              <style>
-                .cls-1 {
-                  fill: #f22f46;
-                }
-              </style>
-            </defs>
-            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
-        </a>
-      </p>
-      <p>
-        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
-      </p>
-    </footer>
-
-    <script>
-      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
-      const baseUrl = new URL(location.href);
-      baseUrl.pathname = baseUrl
-        .pathname
-        .replace(/\/index\.html$/, '');
-      delete baseUrl.hash;
-      delete baseUrl.search;
-      const fullUrl = baseUrl
-        .href
-        .substr(0, baseUrl.href.length - 1);
-      const functionRoots = document.querySelectorAll('span.function-root');
-
-      functionRoots.forEach(element => {
-        element.innerText = fullUrl
-      })
-    </script>
-  </body>
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                               target="_blank"
+                               rel="noopener">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a SMS webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/create-invoice">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
 </html>

--- a/stripe-sms-receipt/assets/index.html
+++ b/stripe-sms-receipt/assets/index.html
@@ -1,89 +1,91 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Get started with your Twilio Functions!</title>
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="stylesheet" href="https://unpkg.com/normalize.css/normalize.css">
-    <link rel="stylesheet" href="https://unpkg.com/milligram/dist/milligram.min.css">
-    <style>
-      body {
-        padding: 20px;
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-      }
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
 
-      div[role="main"] {
-        flex: 1;
-      }
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+        <style>
+         ol.steps > li > form {
+             padding-left: 2rem;
+         }
+        </style>
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This app shows you how to programmatically send a payment receipt URL
+                        to your customer via SMS using a
+                        <a href="https://stripe.com/docs/webhooks" target="_blank" rel="noopener">
+                            Stripe webhook event
+                        </a>
+                        as a trigger.
+                    </p>
+                    <ol class="steps">
+                        <li>Before you can test your app, you need to add a
+                            <a href="https://dashboard.stripe.com/webhooks" target="_blank" rel="noopener">
+                                Stripe Webhook
+                            </a>
+                            and set the URL to
+                            <form>
+                                <label for="twilio-webhook">Stripe Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/send-sms-receipt">
+                            </form>
+                        </li>
+                        <li>Select "All Events" and save the webhook</li>
+                        <li>
+                            To test the app, initiate a payment from Stripe. You should receive an
+                            SMS receipt to the phone number on the payment
+                        </li>
+                    </ol>
+                </section>
 
-      footer {
-        text-align: center;
-      }
-
-      footer p {
-        margin-bottom: 0;
-      }
-
-      #twilio-logo {
-        width: 50px;
-        height: 50px;
-      }
-    </style>
-  </head>
-  <body>
-    <header>
-      <h1>Welcome to your new Twilio App</h1>
-    </header>
-    <div role="main">
-      <section>
-        <h3>Get started with your app</h3>
-        <p>This app shows you how to programmatically send a payment receipt URL to your customer via SMS using a <a href="https://stripe.com/docs/webhooks">Stripe webhook event</a> as a trigger.</p>
-        <ol>
-          <li>Before you can test your app, you need to add a <a href="https://dashboard.stripe.com/webhooks"> Stripe Webhook</a> and set the URL to <code><span class="function-root"></span>/send-sms-receipt</code></li>
-          <li>Select "All Events" and save the webhook.</li>
-          <li>To test the app, initiate a payment from Stripe. You should receive an SMS receipt to the phone number on the payment.</li>
-        </ol>
-      </section>
-      <!-- EDIT_CODE -->
-    </div>
-    <footer>
-      <p>
-        <a href="https://www.twilio.com/">
-          <svg id="twilio-logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
-            <defs>
-              <style>
-                .cls-1 {
-                  fill: #f22f46;
-                }
-              </style>
-            </defs>
-            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
-        </a>
-      </p>
-      <p>
-        <a href="https://www.twilio.com/code-exchange">Learn about other things you can build with Twilio</a>
-      </p>
-    </footer>
-
-    <script>
-      // This code will replace the content of any <span class="function-root"></span> with the base path of the URL
-      const baseUrl = new URL(location.href);
-      baseUrl.pathname = baseUrl
-        .pathname
-        .replace(/\/index\.html$/, '');
-      delete baseUrl.hash;
-      delete baseUrl.search;
-      const fullUrl = baseUrl
-        .href
-        .substr(0, baseUrl.href.length - 1);
-      const functionRoots = document.querySelectorAll('span.function-root');
-
-      functionRoots.forEach(element => {
-        element.innerText = fullUrl
-      })
-    </script>
-  </body>
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
 </html>


### PR DESCRIPTION
Migrates a third batch of apps to use redesigned `index.html` files:

- `airtable`
- `sms-broadcast`
- `stripe-payment-link-sms`
- `stripe-sms-receipt`

<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

<!-- a short description of your pull request -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
