### PR TITLE
fix(funlet-find-me): adjust logic to continue hunting

### DIFF
--- a/funlet-find-me/functions/funlet-find-me.js
+++ b/funlet-find-me/functions/funlet-find-me.js
@@ -42,22 +42,22 @@ let config = {
 
   // recording URL or text message to say,
   // e.g. asking the recipient to press a key to accept the call
-  message: fromNumber =>
+  message: (fromNumber) =>
     `You are receiving a call from ${fromNumber}. Press any key to accept.`,
 
   // language code for conversion of text-to-speech messages,
   // e.g. 'en' or 'en-gb'
-  language: "en",
+  language: 'en',
 
   // voice for text-to-speech messages, one of 'man', 'woman' or 'alice'
-  voice: "alice",
+  voice: 'alice',
 
   // whether to request the recipient to press a key to accept the call
   humanCheck: true,
 
   // fallback URL where further instructions are requested
   // when the forwarding call fails
-  fallbackUrl: ""
+  fallbackUrl: '',
 };
 
 /*
@@ -67,24 +67,24 @@ let config = {
 */
 
 // Copied from Simple Message Funlet
-function readListParam( name, params ) {
+function readListParam(name, params) {
   let array = [];
 
-  const INDEXED_PARAM_REGEX = new RegExp( '^' + name + '\\[([0-9]+)\\]$' );
-  for( let property of Object.keys(params) ) {
-    let matches = INDEXED_PARAM_REGEX.exec( property );
-    if( matches !== null ) {
+  const INDEXED_PARAM_REGEX = new RegExp('^' + name + '\\[([0-9]+)\\]$');
+  for (let property of Object.keys(params)) {
+    let matches = INDEXED_PARAM_REGEX.exec(property);
+    if (matches !== null) {
       let index = matches[1];
-      array[ index ] = params[ property ];
+      array[index] = params[property];
     }
   }
 
-  if ( params.hasOwnProperty( name ) ) {
-    let value = params[ name ];
-    if ( typeof value === "string" ) {
-      array.push( value );
-    } else if ( Array.isArray( value ) ) {
-      array = array.concat( value );
+  if (params.hasOwnProperty(name)) {
+    let value = params[name];
+    if (typeof value === 'string') {
+      array.push(value);
+    } else if (Array.isArray(value)) {
+      array = array.concat(value);
     }
   }
 
@@ -92,15 +92,14 @@ function readListParam( name, params ) {
 }
 
 // Copied from Simple Message Funlet
-function readEnvList( name, start, end, env ) {
+function readEnvList(name, start, end, env) {
   let array = [];
 
-  for ( let i=start; i<=end; i++ ) {
-    let
-      key = name + i,
-      value = env[ key ];
-    if ( typeof value === "string" ) {
-      array.push( value );
+  for (let i = start; i <= end; i++) {
+    let key = name + i,
+      value = env[key];
+    if (typeof value === 'string') {
+      array.push(value);
     }
   }
 
@@ -127,19 +126,17 @@ function readEnvList( name, start, end, env ) {
 function getPhoneNumbers(params, env, config) {
   let phoneNumbers = [];
 
-  function addIfNotEmpty( phoneNumber ) {
-    if ( typeof phoneNumber === "string" && phoneNumber !== "" ) {
-      phoneNumbers.push( phoneNumber );
+  function addIfNotEmpty(phoneNumber) {
+    if (typeof phoneNumber === 'string' && phoneNumber !== '') {
+      phoneNumbers.push(phoneNumber);
     }
   }
 
-  readListParam( "PhoneNumbers", params )
-    .forEach( addIfNotEmpty );
-  readEnvList( "FUNLET_FINDME_PHONE_NUMBER", 1, 5, env )
-    .forEach( addIfNotEmpty );
+  readListParam('PhoneNumbers', params).forEach(addIfNotEmpty);
+  readEnvList('FUNLET_FINDME_PHONE_NUMBER', 1, 5, env).forEach(addIfNotEmpty);
 
-  if ( Array.isArray(config.phoneNumbers) ) {
-    config.phoneNumbers.forEach( addIfNotEmpty );
+  if (Array.isArray(config.phoneNumbers)) {
+    config.phoneNumbers.forEach(addIfNotEmpty);
   }
 
   return phoneNumbers;
@@ -147,24 +144,25 @@ function getPhoneNumbers(params, env, config) {
 
 function getTimeout(params, env, config) {
   let timeout = params.Timeout || env.FUNLET_FINDME_TIMEOUT;
-  if ( typeof timeout === "string" && !isNaN(timeout) ) {
+  if (typeof timeout === 'string' && !isNaN(timeout)) {
     return Number(timeout);
   }
   return config.timeout;
 }
 
 function isWhisper(params, env, config) {
-  return ( typeof params.Whisper === "string" );
+  return typeof params.Whisper === 'string';
 }
 
 function getMessage(params, env, config) {
-  const caller = params.From || params.Caller || "";
-  return params.Message ||
+  const caller = params.From || params.Caller || '';
+  return (
+    params.Message ||
     env.FUNLET_FINDME_MESSAGE ||
-    ( typeof config.message === "function"?
-        config.message( spell(caller) ):
-        config.message
-    );
+    (typeof config.message === 'function'
+      ? config.message(spell(caller))
+      : config.message)
+  );
 }
 
 function getLanguage(params, env, config) {
@@ -176,36 +174,34 @@ function getVoice(params, env, config) {
 }
 
 function isHumanCheckRequired(params, env, config) {
-  if ( typeof params.HumanCheck === "string" ) {
-    return params.HumanCheck !== "false";
+  if (typeof params.HumanCheck === 'string') {
+    return params.HumanCheck !== 'false';
   }
-  if ( typeof env.FUNLET_FINDME_HUMAN_CHECK === "string" ) {
-    return env.FUNLET_FINDME_HUMAN_CHECK !== "false";
+  if (typeof env.FUNLET_FINDME_HUMAN_CHECK === 'string') {
+    return env.FUNLET_FINDME_HUMAN_CHECK !== 'false';
   }
   return config.humanCheck;
 }
 
 function getDigits(params, env, config) {
-  if ( typeof params.Digits === "string" ) {
-   return params.Digits;
+  if (typeof params.Digits === 'string') {
+    return params.Digits;
   }
   return null;
 }
 
 function isDialDone(params, env, config) {
-  return (typeof params.Dial === "string" );
+  return typeof params.Dial === 'string';
 }
 
 // Copied from Forward Funlet
 function getCallStatus(params, env, config) {
-  const NO_CALL_STATUS = "";
+  const NO_CALL_STATUS = '';
   return params.DialStatus || params.DialCallStatus || NO_CALL_STATUS;
 }
 
 function getFallbackUrl(params, env, config) {
-  return params.FailUrl ||
-    env.FUNLET_FINDME_FALLBACK_URL ||
-    config.fallbackUrl;
+  return params.FailUrl || env.FUNLET_FINDME_FALLBACK_URL || config.fallbackUrl;
 }
 
 /*
@@ -217,41 +213,43 @@ function getFallbackUrl(params, env, config) {
   produced in response to each stage of the Funlet.
 */
 
+function getBaseUrl(context) {
+  return `https://${context.DOMAIN_NAME}${context.PATH}`;
+}
+
 // Copied from Whisper Funlet
-function spell( numberString ) {
+function spell(numberString) {
   const PAUSE = '. ';
-  return numberString.split('').join(PAUSE)+PAUSE;
+  return numberString.split('').join(PAUSE) + PAUSE;
 }
 
 // Copied from Forward Funlet
-function getForwardActionUrl( fallbackUrl ) {
-  const BASE_URL = ".";
-  let actionUrl = BASE_URL + "?Dial=true";
-  if ( fallbackUrl !== "" ) {
-    actionUrl += "&" + encodeURIComponent(fallbackUrl);
+function getForwardActionUrl(baseUrl, fallbackUrl) {
+  let actionUrl = baseUrl + '?Dial=true';
+  if (fallbackUrl !== '') {
+    actionUrl += '&' + encodeURIComponent(fallbackUrl);
   }
   return actionUrl;
 }
 
 // Copied from Call Me Funlet
-function getWhisperUrl( params ) {
-  const
-   BASE_WHISPER_URL=".?Whisper=true",
-   SEP="&";
+function getWhisperUrl(baseUrl, params) {
+  const BASE_WHISPER_URL = baseUrl + '?Whisper=true',
+    SEP = '&';
 
   let whisperUrl = BASE_WHISPER_URL;
 
-  function copyStringParam( name ) {
+  function copyStringParam(name) {
     let value = params[name];
-    if ( typeof value === "string" ) {
-      whisperUrl += SEP + name + "=" + encodeURIComponent( value );
+    if (typeof value === 'string') {
+      whisperUrl += SEP + name + '=' + encodeURIComponent(value);
     }
   }
 
-  copyStringParam( "Message" );
-  copyStringParam( "Language" );
-  copyStringParam( "Voice" );
-  copyStringParam( "HumanCheck" );
+  copyStringParam('Message');
+  copyStringParam('Language');
+  copyStringParam('Voice');
+  copyStringParam('HumanCheck');
 
   return whisperUrl;
 }
@@ -280,57 +278,63 @@ function getWhisperUrl( params ) {
         fallback URL when the last forwarding number has been tried.
 */
 function findMeStage1(
-  response, forwardingNumbers, timeout, whisperUrl, fallbackUrl
+  response,
+  forwardingNumbers,
+  timeout,
+  whisperUrl,
+  fallbackUrl,
+  baseUrl
 ) {
   const MAX_FORWARDING_NUMBERS = 10;
 
-  if ( forwardingNumbers.length === 0 ) {
-    if ( fallbackUrl !== "" ) {
-      response.redirect( fallbackUrl );
+  if (forwardingNumbers.length === 0) {
+    if (fallbackUrl !== '') {
+      response.redirect(fallbackUrl);
     } else {
       response.hangup();
     }
     return;
   }
 
-  if ( forwardingNumbers.length > MAX_FORWARDING_NUMBERS ) {
+  if (forwardingNumbers.length > MAX_FORWARDING_NUMBERS) {
     forwardingNumbers.length = MAX_FORWARDING_NUMBERS;
   }
 
   let otherForwardingNumbers = Array.from(forwardingNumbers);
   let firstForwardingNumber = otherForwardingNumbers.shift();
-  let actionUrl = getForwardActionUrl( fallbackUrl );
-  otherForwardingNumbers.forEach( forwardingNumber =>
-    actionUrl +=
-      '&' +
-      encodeURIComponent('PhoneNumbers[]') +
-      '=' +
-      encodeURIComponent( forwardingNumber )
+  let actionUrl = getForwardActionUrl(baseUrl, fallbackUrl);
+  otherForwardingNumbers.forEach(
+    (forwardingNumber, idx) =>
+      (actionUrl +=
+        '&' +
+        encodeURIComponent('PhoneNumbers[' + idx + ']') +
+        '=' +
+        encodeURIComponent(forwardingNumber))
   );
 
   let dial = response.dial({
     action: actionUrl,
-    timeout: timeout
+    timeout: timeout,
   });
-  dial.number( {url:whisperUrl}, firstForwardingNumber );
+  dial.number({ url: whisperUrl }, firstForwardingNumber);
 }
 
 // Copied from Simple Message Funlet
 function simpleMessage(response, message, language, voice) {
-  if ( message.length === 0 ) {
+  if (message.length === 0) {
     return;
   }
-  if ( message.startsWith("http") ) {
+  if (message.startsWith('http')) {
     response.play({}, message);
   } else {
-    response.say({language:language, voice:voice}, message);
+    response.say({ language: language, voice: voice }, message);
   }
 }
 
 // Copied from Simple Menu Funlet
 function gatherDigits(response, maxDigits, message, language, voice) {
   simpleMessage(
-    response.gather({numDigits: maxDigits}),
+    response.gather({ numDigits: maxDigits }),
     message,
     language,
     voice
@@ -340,7 +344,7 @@ function gatherDigits(response, maxDigits, message, language, voice) {
 // Copied from Whisper Funlet
 function whisperStage1(response, humanCheck, message, language, voice) {
   gatherDigits(response, 1, message, language, voice);
-  if ( humanCheck ) {
+  if (humanCheck) {
     response.hangup();
   }
 }
@@ -348,11 +352,13 @@ let findMeStage2 = whisperStage1;
 
 // Copied from Whisper Funlet
 function whisperStage2(response, digits) {
-  if ( digits === null ) {
+  if (digits === null) {
     return false;
   }
-  if ( digits==="" ) {
+  if (digits === '') {
     response.hangup();
+  } else {
+    response.say('Connecting');
   }
   return true;
 }
@@ -360,19 +366,14 @@ let findMeStage3 = whisperStage2;
 
 // Copied from Forward Funlet
 function forwardStage2(response, isDialDone, callStatus, fallbackUrl) {
-  if (isDialDone) {
-    if (
-      callStatus !== "answered" &&
-      callStatus !== "completed" &&
-      fallbackUrl !== ""
-    ) {
-      response.redirect( fallbackUrl );
-    } else {
-      response.hangup();
-    }
+  if (isDialDone && (callStatus === 'answered' || callStatus === 'completed')) {
+    response.hangup();
+    return true;
+  } else {
+    return false;
   }
-  return isDialDone;
 }
+
 let findMeStage4 = forwardStage2;
 
 /*
@@ -383,11 +384,10 @@ let findMeStage4 = forwardStage2;
   such as the ones generated by Twilio events.
 */
 
-exports.handler = function(context, event, callback) {
+exports.handler = function (context, event, callback) {
   const NO_ERROR = null;
 
-  let
-    response = new Twilio.twiml.VoiceResponse(),
+  let response = new Twilio.twiml.VoiceResponse(),
     isDial = isDialDone(event, context, config),
     callStatus = getCallStatus(event, context, config),
     fallbackUrl = getFallbackUrl(event, context, config),
@@ -398,16 +398,23 @@ exports.handler = function(context, event, callback) {
     voice = getVoice(event, context, config),
     forwardingNumbers = getPhoneNumbers(event, context, config),
     timeout = getTimeout(event, context, config),
-    whisperUrl = getWhisperUrl(event);
+    baseUrl = getBaseUrl(context),
+    whisperUrl = getWhisperUrl(baseUrl, event);
 
-  findMeStage4(response, isDial, callStatus, fallbackUrl) ||
-  findMeStage3(response, digits) ||
-  (isWhisper(event, context, config)?
-    findMeStage2(response, humanCheckRequired, message, language, voice):
-    findMeStage1(
-      response, forwardingNumbers, timeout, whisperUrl, fallbackUrl
-    )
-  );
+  if (isWhisper(event, context, config)) {
+    findMeStage3(response, digits) ||
+      findMeStage2(response, humanCheckRequired, message, language, voice);
+  } else {
+    findMeStage4(response, isDial, callStatus, fallbackUrl) ||
+      findMeStage1(
+        response,
+        forwardingNumbers,
+        timeout,
+        whisperUrl,
+        fallbackUrl,
+        baseUrl
+      );
+  }
 
   callback(NO_ERROR, response);
 };
@@ -430,14 +437,14 @@ exports.input = {
   isHumanCheckRequired: isHumanCheckRequired,
   getDigits: getDigits,
   isDialDone: isDialDone,
-  getFallbackUrl: getFallbackUrl
+  getFallbackUrl: getFallbackUrl,
 };
 
 exports.output = {
   findMeStage1: findMeStage1,
   findMeStage2: findMeStage2,
   findMeStage3: findMeStage3,
-  findMeStage4: findMeStage4
+  findMeStage4: findMeStage4,
 };
 
 /*

--- a/funlet-find-me/tests/funlet-find-me.test.js
+++ b/funlet-find-me/tests/funlet-find-me.test.js
@@ -2,596 +2,647 @@ const funlet = require('../functions/funlet-find-me');
 const runtime = require('../../test/test-helper');
 const Twilio = require('twilio');
 
-const PHONE_NUMBER1='415-555-5501';
-const PHONE_NUMBER2='415-555-5502';
-const PHONE_NUMBER3='415-555-5503';
-const PHONE_NUMBER4='415-555-5504';
-const PHONE_NUMBER5='415-555-5505';
-const PHONE_NUMBER6='415-555-5506';
-const PHONE_NUMBER7='415-555-5507';
-const PHONE_NUMBER8='415-555-5508';
-const PHONE_NUMBER9='415-555-5509';
-const PHONE_NUMBER10='415-555-5510';
-const PHONE_NUMBER11='415-555-5511';
-const PHONE_NUMBER12='415-555-5512';
-const DEFAULT_PHONE_NUMBERS=[];
+const PHONE_NUMBER1 = '415-555-5501';
+const PHONE_NUMBER2 = '415-555-5502';
+const PHONE_NUMBER3 = '415-555-5503';
+const PHONE_NUMBER4 = '415-555-5504';
+const PHONE_NUMBER5 = '415-555-5505';
+const PHONE_NUMBER6 = '415-555-5506';
+const PHONE_NUMBER7 = '415-555-5507';
+const PHONE_NUMBER8 = '415-555-5508';
+const PHONE_NUMBER9 = '415-555-5509';
+const PHONE_NUMBER10 = '415-555-5510';
+const PHONE_NUMBER11 = '415-555-5511';
+const PHONE_NUMBER12 = '415-555-5512';
+const DEFAULT_PHONE_NUMBERS = [];
 
-const TIMEOUT_STRING="42";
-const TIMEOUT=42;
-const DEFAULT_TIMEOUT=60;
+const TIMEOUT_STRING = '42';
+const TIMEOUT = 42;
+const DEFAULT_TIMEOUT = 60;
 
-const WHISPER=true;
-const NO_WHISPER=false;
+const WHISPER = true;
+const NO_WHISPER = false;
 
-const FROM_NUMBER="+19165550123";
-const SPELLED_FROM_NUMBER="+. 1. 9. 1. 6. 5. 5. 5. 0. 1. 2. 3. ";
+const FROM_NUMBER = '+19165550123';
+const SPELLED_FROM_NUMBER = '+. 1. 9. 1. 6. 5. 5. 5. 0. 1. 2. 3. ';
 
-const RECORDED_MESSAGE="https://example.com/recorded-message.mp3";
-const TEXT_MESSAGE="Text message";
-const MESSAGE=TEXT_MESSAGE;
-const DEFAULT_MESSAGE=
-  'You are receiving a call from '+SPELLED_FROM_NUMBER+'. '+
+const RECORDED_MESSAGE = 'https://example.com/recorded-message.mp3';
+const TEXT_MESSAGE = 'Text message';
+const MESSAGE = TEXT_MESSAGE;
+const DEFAULT_MESSAGE =
+  'You are receiving a call from ' +
+  SPELLED_FROM_NUMBER +
+  '. ' +
   'Press any key to accept.';
 
-const CUSTOM_MESSAGE="Custom Message";
-const CUSTOM_MESSAGE_ENCODED="Custom%20Message";
+const CUSTOM_MESSAGE = 'Custom Message';
+const CUSTOM_MESSAGE_ENCODED = 'Custom%20Message';
 
-const ENGLISH="en";
-const FRENCH="fr";
-const DEFAULT_LANGUAGE=ENGLISH;
+const ENGLISH = 'en';
+const FRENCH = 'fr';
+const DEFAULT_LANGUAGE = ENGLISH;
 
-const MAN="man";
-const WOMAN="woman";
-const ALICE="alice";
-const DEFAULT_VOICE=ALICE;
+const MAN = 'man';
+const WOMAN = 'woman';
+const ALICE = 'alice';
+const DEFAULT_VOICE = ALICE;
 
 const DEFAULT_HUMAN_CHECK = true;
 
 const NO_DIGITS = null;
-const EMPTY_DIGITS="";
-const NON_EMPTY_DIGITS="5";
+const EMPTY_DIGITS = '';
+const NON_EMPTY_DIGITS = '5';
 
 const DIAL_DONE = true;
 const DIAL_NOT_DONE = false;
 
-const NO_CALL_STATUS="";
-const CALL_ANSWERED="answered";
-const CALL_COMPLETED="completed";
-const CALL_BUSY="busy";
+const NO_CALL_STATUS = '';
+const CALL_ANSWERED = 'answered';
+const CALL_COMPLETED = 'completed';
+const CALL_BUSY = 'busy';
 
-const FALLBACK_URL="https://example.com/please-try-later.mp3";
-const FALLBACK_URL_ENCODED="https%3A%2F%2Fexample.com%2Fplease-try-later.mp3";
-const NO_FALLBACK_URL="";
-const DEFAULT_FALLBACK_URL=NO_FALLBACK_URL;
+const FALLBACK_URL = 'https://example.com/please-try-later.mp3';
+const FALLBACK_URL_ENCODED = 'https%3A%2F%2Fexample.com%2Fplease-try-later.mp3';
+const NO_FALLBACK_URL = '';
+const DEFAULT_FALLBACK_URL = NO_FALLBACK_URL;
 
-const DEFAULT_WHISPER_URL=".?Whisper=true";
-const XML_DEFAULT_WHISPER_URL=".?Whisper=true";
-const XML_WHISPER_URL_WITH_CUSTOM_MESSAGE=
-  XML_DEFAULT_WHISPER_URL+"&amp;Message="+CUSTOM_MESSAGE_ENCODED;
+const EXAMPLE_BASE_URL = 'https://demo.twil.io/funlet-find-me';
+const EXAMPLE_CONTEXT = {
+  DOMAIN_NAME: 'demo.twil.io',
+  PATH: '/funlet-find-me',
+};
 
-const XML_DECLARATION='<?xml version="1.0" encoding="UTF-8"?>';
+const DEFAULT_WHISPER_URL = EXAMPLE_BASE_URL + '?Whisper=true';
+const XML_DEFAULT_WHISPER_URL = EXAMPLE_BASE_URL + '?Whisper=true';
+const XML_WHISPER_URL_WITH_CUSTOM_MESSAGE =
+  XML_DEFAULT_WHISPER_URL + '&amp;Message=' + CUSTOM_MESSAGE_ENCODED;
 
-const FULL_RESPONSE_FIND_ME_1_1=
-  XML_DECLARATION+
-  '<Response>'+
-    '<Dial '+
-      'action=".?Dial=true'+
-        '&amp;PhoneNumbers%5B%5D='+PHONE_NUMBER2+
-        '&amp;PhoneNumbers%5B%5D='+PHONE_NUMBER3+
-      '" '+
-      'timeout="'+DEFAULT_TIMEOUT+'"'+
-    '>'+
-      '<Number url="'+XML_DEFAULT_WHISPER_URL+'">'+PHONE_NUMBER1+'</Number>'+
-    '</Dial>'+
+const XML_DECLARATION = '<?xml version="1.0" encoding="UTF-8"?>';
+
+const FULL_RESPONSE_FIND_ME_1_1 =
+  XML_DECLARATION +
+  '<Response>' +
+  '<Dial ' +
+  'action="' +
+  EXAMPLE_BASE_URL +
+  '?Dial=true' +
+  '&amp;PhoneNumbers%5B0%5D=' +
+  PHONE_NUMBER2 +
+  '&amp;PhoneNumbers%5B1%5D=' +
+  PHONE_NUMBER3 +
+  '" ' +
+  'timeout="' +
+  DEFAULT_TIMEOUT +
+  '"' +
+  '>' +
+  '<Number url="' +
+  XML_DEFAULT_WHISPER_URL +
+  '">' +
+  PHONE_NUMBER1 +
+  '</Number>' +
+  '</Dial>' +
   '</Response>';
 
-const FULL_RESPONSE_FIND_ME_1_3=
-  XML_DECLARATION+
-  '<Response>'+
-    '<Dial '+
-      'action=".?Dial=true'+
-        '&amp;PhoneNumbers%5B%5D='+PHONE_NUMBER2+
-        '&amp;PhoneNumbers%5B%5D='+PHONE_NUMBER3+
-      '" '+
-      'timeout="'+TIMEOUT+'"'+
-    '>'+
-      '<Number url="'+XML_WHISPER_URL_WITH_CUSTOM_MESSAGE+'">'+
-        PHONE_NUMBER1+
-      '</Number>'+
-    '</Dial>'+
+const FULL_RESPONSE_FIND_ME_1_3 =
+  XML_DECLARATION +
+  '<Response>' +
+  '<Dial ' +
+  'action="' +
+  EXAMPLE_BASE_URL +
+  '?Dial=true' +
+  '&amp;PhoneNumbers%5B0%5D=' +
+  PHONE_NUMBER2 +
+  '&amp;PhoneNumbers%5B1%5D=' +
+  PHONE_NUMBER3 +
+  '" ' +
+  'timeout="' +
+  TIMEOUT +
+  '"' +
+  '>' +
+  '<Number url="' +
+  XML_WHISPER_URL_WITH_CUSTOM_MESSAGE +
+  '">' +
+  PHONE_NUMBER1 +
+  '</Number>' +
+  '</Dial>' +
   '</Response>';
 
-const FULL_RESPONSE_FIND_ME_1_4=
-  XML_DECLARATION+
-  '<Response>'+
-    '<Dial '+
-      'action=".?Dial=true'+
-        '&amp;PhoneNumbers%5B%5D='+PHONE_NUMBER2+
-        '&amp;PhoneNumbers%5B%5D='+PHONE_NUMBER3+
-        '&amp;PhoneNumbers%5B%5D='+PHONE_NUMBER4+
-        '&amp;PhoneNumbers%5B%5D='+PHONE_NUMBER5+
-        '&amp;PhoneNumbers%5B%5D='+PHONE_NUMBER6+
-        '&amp;PhoneNumbers%5B%5D='+PHONE_NUMBER7+
-        '&amp;PhoneNumbers%5B%5D='+PHONE_NUMBER8+
-        '&amp;PhoneNumbers%5B%5D='+PHONE_NUMBER9+
-        '&amp;PhoneNumbers%5B%5D='+PHONE_NUMBER10+
-      '" '+
-      'timeout="'+DEFAULT_TIMEOUT+'"'+
-    '>'+
-      '<Number url="'+XML_DEFAULT_WHISPER_URL+'">'+PHONE_NUMBER1+'</Number>'+
-    '</Dial>'+
+const FULL_RESPONSE_FIND_ME_1_4 =
+  XML_DECLARATION +
+  '<Response>' +
+  '<Dial ' +
+  'action="' +
+  EXAMPLE_BASE_URL +
+  '?Dial=true' +
+  '&amp;PhoneNumbers%5B0%5D=' +
+  PHONE_NUMBER2 +
+  '&amp;PhoneNumbers%5B1%5D=' +
+  PHONE_NUMBER3 +
+  '&amp;PhoneNumbers%5B2%5D=' +
+  PHONE_NUMBER4 +
+  '&amp;PhoneNumbers%5B3%5D=' +
+  PHONE_NUMBER5 +
+  '&amp;PhoneNumbers%5B4%5D=' +
+  PHONE_NUMBER6 +
+  '&amp;PhoneNumbers%5B5%5D=' +
+  PHONE_NUMBER7 +
+  '&amp;PhoneNumbers%5B6%5D=' +
+  PHONE_NUMBER8 +
+  '&amp;PhoneNumbers%5B7%5D=' +
+  PHONE_NUMBER9 +
+  '&amp;PhoneNumbers%5B8%5D=' +
+  PHONE_NUMBER10 +
+  '" ' +
+  'timeout="' +
+  DEFAULT_TIMEOUT +
+  '"' +
+  '>' +
+  '<Number url="' +
+  XML_DEFAULT_WHISPER_URL +
+  '">' +
+  PHONE_NUMBER1 +
+  '</Number>' +
+  '</Dial>' +
   '</Response>';
 
-const FULL_RESPONSE_FIND_ME_1_5=FULL_RESPONSE_FIND_ME_1_4;
+const FULL_RESPONSE_FIND_ME_1_5 = FULL_RESPONSE_FIND_ME_1_4;
 
-const FULL_RESPONSE_FIND_ME_1_6=
-  XML_DECLARATION+
-  '<Response>'+
-    '<Hangup/>'+
+const FULL_RESPONSE_FIND_ME_1_6 =
+  XML_DECLARATION + '<Response>' + '<Hangup/>' + '</Response>';
+
+const FULL_RESPONSE_FIND_ME_1_7 =
+  XML_DECLARATION +
+  '<Response>' +
+  '<Redirect>' +
+  FALLBACK_URL +
+  '</Redirect>' +
   '</Response>';
 
-const FULL_RESPONSE_FIND_ME_1_7=
-  XML_DECLARATION+
-  '<Response>'+
-    '<Redirect>'+FALLBACK_URL+'</Redirect>'+
+const FULL_RESPONSE_FIND_ME_2_1 =
+  XML_DECLARATION +
+  '<Response>' +
+  '<Gather numDigits="1">' +
+  '<Play>' +
+  RECORDED_MESSAGE +
+  '</Play>' +
+  '</Gather>' +
+  '<Hangup/>' +
   '</Response>';
 
-const FULL_RESPONSE_FIND_ME_2_1=
-  XML_DECLARATION+
-  '<Response>'+
-    '<Gather numDigits="1">'+
-      '<Play>'+RECORDED_MESSAGE+'</Play>'+
-    '</Gather>'+
-    '<Hangup/>'+
+const FULL_RESPONSE_FIND_ME_3_1 =
+  XML_DECLARATION + '<Response><Say>Connecting</Say></Response>';
+
+const FULL_RESPONSE_FIND_ME_4_3 =
+  XML_DECLARATION +
+  '<Response>' +
+  '<Redirect>' +
+  FALLBACK_URL +
+  '</Redirect>' +
   '</Response>';
 
-const FULL_RESPONSE_FIND_ME_3_1=
-  XML_DECLARATION+
-  '<Response/>';
+beforeAll(() => runtime.setup());
 
-const FULL_RESPONSE_FIND_ME_4_3=
-  XML_DECLARATION+
-  '<Response>'+
-    '<Redirect>'+FALLBACK_URL+'</Redirect>'+
-  '</Response>';
+test('[FINDME-INPUT-PHONE-NUMBERS-1] Read Single Phone Number from Event', () => {
+  expect(
+    funlet.input.getPhoneNumbers({ PhoneNumbers: PHONE_NUMBER1 }, {}, {})
+  ).toEqual([PHONE_NUMBER1]);
+});
 
-beforeAll( () =>
-  runtime.setup()
+test('[FINDME-INPUT-PHONE-NUMBERS-2] Read List of Phone Numbers from Event', () => {
+  expect(
+    funlet.input.getPhoneNumbers(
+      {
+        PhoneNumbers: [PHONE_NUMBER1, PHONE_NUMBER2, PHONE_NUMBER3],
+      },
+      {},
+      {}
+    )
+  ).toEqual([PHONE_NUMBER1, PHONE_NUMBER2, PHONE_NUMBER3]);
+});
+
+test(
+  '[FINDME-INPUT-PHONE-NUMBERS-3] ' +
+    'Read Indexed List of Phone Numbers from Event',
+  () => {
+    expect(
+      funlet.input.getPhoneNumbers(
+        {
+          'PhoneNumbers[0]': PHONE_NUMBER1,
+          'PhoneNumbers[1]': PHONE_NUMBER2,
+          'PhoneNumbers[2]': PHONE_NUMBER3,
+        },
+        {},
+        {}
+      )
+    ).toEqual([PHONE_NUMBER1, PHONE_NUMBER2, PHONE_NUMBER3]);
+  }
 );
 
-test('[FINDME-INPUT-PHONE-NUMBERS-1] Read Single Phone Number from Event',
-() => {
+test(
+  '[FINDME-INPUT-PHONE-NUMBERS-4] ' +
+    'Read Single Phone Number from Environment',
+  () => {
+    expect(
+      funlet.input.getPhoneNumbers(
+        {},
+        {
+          FUNLET_FINDME_PHONE_NUMBER1: PHONE_NUMBER1,
+        },
+        {}
+      )
+    ).toEqual([PHONE_NUMBER1]);
+  }
+);
+
+test(
+  '[FINDME-INPUT-PHONE-NUMBERS-5] ' +
+    'Read Five Phone Numbers from Environment',
+  () => {
+    expect(
+      funlet.input.getPhoneNumbers(
+        {},
+        {
+          FUNLET_FINDME_PHONE_NUMBER1: PHONE_NUMBER1,
+          FUNLET_FINDME_PHONE_NUMBER2: PHONE_NUMBER2,
+          FUNLET_FINDME_PHONE_NUMBER3: PHONE_NUMBER3,
+          FUNLET_FINDME_PHONE_NUMBER4: PHONE_NUMBER4,
+          FUNLET_FINDME_PHONE_NUMBER5: PHONE_NUMBER5,
+        },
+        {}
+      )
+    ).toEqual([
+      PHONE_NUMBER1,
+      PHONE_NUMBER2,
+      PHONE_NUMBER3,
+      PHONE_NUMBER4,
+      PHONE_NUMBER5,
+    ]);
+  }
+);
+
+test(
+  '[FINDME-INPUT-PHONE-NUMBERS-6] ' + 'Read Phone Numbers from Script Config',
+  () => {
+    expect(
+      funlet.input.getPhoneNumbers(
+        {},
+        {},
+        {
+          phoneNumbers: [PHONE_NUMBER1, PHONE_NUMBER2, PHONE_NUMBER3],
+        }
+      )
+    ).toEqual([PHONE_NUMBER1, PHONE_NUMBER2, PHONE_NUMBER3]);
+  }
+);
+
+test(
+  '[FINDME-INPUT-PHONE-NUMBERS-7] ' + 'Read Default Phone Numbers from Script',
+  () => {
+    expect(funlet.config.phoneNumbers).toEqual(DEFAULT_PHONE_NUMBERS);
+  }
+);
+
+test('[FINDME-INPUT-PHONE_NUMBERS-7] Skip empty values', () => {
   expect(
-    funlet.input.getPhoneNumbers({PhoneNumbers:PHONE_NUMBER1}, {}, {})
-  ).toEqual( [PHONE_NUMBER1] );
+    funlet.input.getPhoneNumbers(
+      {},
+      {
+        FUNLET_FINDME_PHONE_NUMBER1: PHONE_NUMBER1,
+        FUNLET_FINDME_PHONE_NUMBER2: '',
+        FUNLET_FINDME_PHONE_NUMBER3: PHONE_NUMBER3,
+        FUNLET_FINDME_PHONE_NUMBER4: '',
+        FUNLET_FINDME_PHONE_NUMBER5: PHONE_NUMBER5,
+      },
+      {}
+    )
+  ).toEqual([PHONE_NUMBER1, PHONE_NUMBER3, PHONE_NUMBER5]);
 });
 
-test('[FINDME-INPUT-PHONE-NUMBERS-2] Read List of Phone Numbers from Event',
-() => {
+test('[FINDME-INPUT-TIMEOUT-1] Read Timeout from Event', () => {
+  expect(funlet.input.getTimeout({ Timeout: TIMEOUT_STRING }, {}, {})).toEqual(
+    TIMEOUT
+  );
+});
+
+test('[FINDME-INPUT-TIMEOUT-2] Read Timeout from Environment', () => {
   expect(
-    funlet.input.getPhoneNumbers({
-      PhoneNumbers:[
-        PHONE_NUMBER1,
-        PHONE_NUMBER2,
-        PHONE_NUMBER3
-      ]
-    }, {}, {})
-  ).toEqual( [
-    PHONE_NUMBER1,
-    PHONE_NUMBER2,
-    PHONE_NUMBER3
-  ] );
+    funlet.input.getTimeout({}, { FUNLET_FINDME_TIMEOUT: TIMEOUT_STRING }, {})
+  ).toEqual(TIMEOUT);
 });
 
-test('[FINDME-INPUT-PHONE-NUMBERS-3] '+
-     'Read Indexed List of Phone Numbers from Event',
-() => {
+test('[FINDME-INPUT-TIMEOUT-3] Read Timeout from Script Config', () => {
+  expect(funlet.input.getTimeout({}, {}, { timeout: TIMEOUT })).toEqual(
+    TIMEOUT
+  );
+});
+
+test('[FINDME-INPUT-TIMEOUT-4] Read Default Timeout from Script Config', () => {
+  expect(funlet.config.timeout).toEqual(DEFAULT_TIMEOUT);
+});
+
+test('[FINDME-INPUT-DIAL-0] Read No Whisper from Event', () => {
+  expect(funlet.input.isWhisper({}, {}, {})).toEqual(NO_WHISPER);
+});
+
+test('[FINDME-INPUT-DIAL-1] Read Whisper from Event', () => {
+  expect(funlet.input.isWhisper({ Whisper: 'true' }, {}, {})).toEqual(WHISPER);
+});
+
+test('[FINDME-INPUT-MESSAGE-1] Read Message from Event', () => {
+  expect(funlet.input.getMessage({ Message: MESSAGE }, {}, {})).toEqual(
+    MESSAGE
+  );
+});
+
+test('[FINDME-INPUT-MESSAGE-2] Read Message from Environment', () => {
   expect(
-    funlet.input.getPhoneNumbers({
-      "PhoneNumbers[0]":PHONE_NUMBER1,
-      "PhoneNumbers[1]":PHONE_NUMBER2,
-      "PhoneNumbers[2]":PHONE_NUMBER3
-    }, {}, {})
-  ).toEqual( [
-    PHONE_NUMBER1,
-    PHONE_NUMBER2,
-    PHONE_NUMBER3
-  ] );
+    funlet.input.getMessage({}, { FUNLET_FINDME_MESSAGE: MESSAGE }, {})
+  ).toEqual(MESSAGE);
 });
 
-test('[FINDME-INPUT-PHONE-NUMBERS-4] '+
-     'Read Single Phone Number from Environment',
-() => {
+test('[FINDME-INPUT-MESSAGE-3] Read Message from Script Config', () => {
+  expect(funlet.input.getMessage({}, {}, { message: MESSAGE })).toEqual(
+    MESSAGE
+  );
+});
+
+test('[FINDME-INPUT-MESSAGE-4] Read Default Message from Script Config', () => {
+  expect(funlet.config.message(SPELLED_FROM_NUMBER)).toEqual(DEFAULT_MESSAGE);
+});
+
+test('[FINDME-INPUT-LANGUAGE-1] Read Language from Event', () => {
+  expect(funlet.input.getLanguage({ Language: FRENCH }, {}, {})).toEqual(
+    FRENCH
+  );
+});
+
+test('[FINDME-INPUT-LANGUAGE-2] Read Language from Environment', () => {
   expect(
-    funlet.input.getPhoneNumbers({}, {
-      FUNLET_FINDME_PHONE_NUMBER1:PHONE_NUMBER1
-    }, {})
-  ).toEqual( [PHONE_NUMBER1] );
+    funlet.input.getLanguage({}, { FUNLET_FINDME_LANGUAGE: FRENCH }, {})
+  ).toEqual(FRENCH);
 });
 
-test('[FINDME-INPUT-PHONE-NUMBERS-5] '+
-     'Read Five Phone Numbers from Environment',
-() => {
+test('[FINDME-INPUT-LANGUAGE-3] Read Language from Script Config', () => {
+  expect(funlet.input.getLanguage({}, {}, { language: FRENCH })).toEqual(
+    FRENCH
+  );
+});
+
+test('[FINDME-INPUT-LANGUAGE-4] Read Default Language from Script Config', () => {
+  expect(funlet.config.language).toEqual(DEFAULT_LANGUAGE);
+});
+
+test('[FINDME-INPUT-VOICE-1] Read Voice from Event', () => {
+  expect(funlet.input.getVoice({ Voice: MAN }, {}, {})).toEqual(MAN);
+});
+
+test('[FINDME-INPUT-VOICE-2] Read Voice from Environment', () => {
+  expect(funlet.input.getVoice({}, { FUNLET_FINDME_VOICE: WOMAN }, {})).toEqual(
+    WOMAN
+  );
+});
+
+test('[FINDME-INPUT-VOICE-3] Read Voice from Script Config', () => {
+  expect(funlet.input.getVoice({}, {}, { voice: WOMAN })).toEqual(WOMAN);
+});
+
+test('[FINDME-INPUT-VOICE-4] Read Default Voice from Script Config', () => {
+  expect(funlet.config.voice).toEqual(DEFAULT_VOICE);
+});
+
+test('[WHISPER-INPUT-HUMAN-CHECK-0] Read Human Check "1" from Event', () => {
   expect(
-    funlet.input.getPhoneNumbers({}, {
-      FUNLET_FINDME_PHONE_NUMBER1:PHONE_NUMBER1,
-      FUNLET_FINDME_PHONE_NUMBER2:PHONE_NUMBER2,
-      FUNLET_FINDME_PHONE_NUMBER3:PHONE_NUMBER3,
-      FUNLET_FINDME_PHONE_NUMBER4:PHONE_NUMBER4,
-      FUNLET_FINDME_PHONE_NUMBER5:PHONE_NUMBER5
-    }, {})
-  ).toEqual( [
-    PHONE_NUMBER1,
-    PHONE_NUMBER2,
-    PHONE_NUMBER3,
-    PHONE_NUMBER4,
-    PHONE_NUMBER5
-  ] );
+    funlet.input.isHumanCheckRequired({ HumanCheck: '1' }, {}, {})
+  ).toEqual(true);
 });
 
-test('[FINDME-INPUT-PHONE-NUMBERS-6] '+
-     'Read Phone Numbers from Script Config',
-() => {
+test('[FINDME-INPUT-HUMAN-CHECK-1] Read Human Check from Event', () => {
   expect(
-    funlet.input.getPhoneNumbers({}, {}, {
-      phoneNumbers: [
-        PHONE_NUMBER1,
-        PHONE_NUMBER2,
-        PHONE_NUMBER3
-      ]
-    })
-  ).toEqual([
-    PHONE_NUMBER1,
-    PHONE_NUMBER2,
-    PHONE_NUMBER3
-  ]);
+    funlet.input.isHumanCheckRequired({ HumanCheck: 'true' }, {}, {})
+  ).toEqual(true);
 });
 
-test('[FINDME-INPUT-PHONE-NUMBERS-7] '+
-     'Read Default Phone Numbers from Script',
-() => {
-  expect( funlet.config.phoneNumbers ).toEqual( DEFAULT_PHONE_NUMBERS );
-});
-
-test('[FINDME-INPUT-PHONE_NUMBERS-7] Skip empty values',
-() => {
-  expect(
-    funlet.input.getPhoneNumbers({}, {
-      FUNLET_FINDME_PHONE_NUMBER1:PHONE_NUMBER1,
-      FUNLET_FINDME_PHONE_NUMBER2:"",
-      FUNLET_FINDME_PHONE_NUMBER3:PHONE_NUMBER3,
-      FUNLET_FINDME_PHONE_NUMBER4:"",
-      FUNLET_FINDME_PHONE_NUMBER5:PHONE_NUMBER5
-    }, {})
-  ).toEqual( [
-    PHONE_NUMBER1,
-    PHONE_NUMBER3,
-    PHONE_NUMBER5
-  ] );
-});
-
-test('[FINDME-INPUT-TIMEOUT-1] Read Timeout from Event',
-() => {
-  expect(
-    funlet.input.getTimeout({Timeout:TIMEOUT_STRING}, {}, {})
-  ).toEqual( TIMEOUT );
-});
-
-test('[FINDME-INPUT-TIMEOUT-2] Read Timeout from Environment',
-() => {
-  expect(
-    funlet.input.getTimeout({}, {FUNLET_FINDME_TIMEOUT:TIMEOUT_STRING}, {})
-  ).toEqual( TIMEOUT );
-});
-
-test('[FINDME-INPUT-TIMEOUT-3] Read Timeout from Script Config',
-() => {
-  expect(
-    funlet.input.getTimeout({}, {}, {timeout: TIMEOUT})
-  ).toEqual( TIMEOUT );
-});
-
-test('[FINDME-INPUT-TIMEOUT-4] Read Default Timeout from Script Config',
-() => {
-  expect( funlet.config.timeout ).toEqual( DEFAULT_TIMEOUT );
-});
-
-test('[FINDME-INPUT-DIAL-0] Read No Whisper from Event',
-() => {
-  expect(
-    funlet.input.isWhisper({}, {}, {})
-  ).toEqual( NO_WHISPER );
-});
-
-test('[FINDME-INPUT-DIAL-1] Read Whisper from Event',
-() => {
-  expect(
-    funlet.input.isWhisper({Whisper:"true"}, {}, {})
-  ).toEqual( WHISPER );
-});
-
-test('[FINDME-INPUT-MESSAGE-1] Read Message from Event',
-() => {
-  expect(
-    funlet.input.getMessage({Message:MESSAGE}, {}, {})
-  ).toEqual( MESSAGE );
-});
-
-test('[FINDME-INPUT-MESSAGE-2] Read Message from Environment',
-() => {
-  expect(
-    funlet.input.getMessage({}, {FUNLET_FINDME_MESSAGE:MESSAGE}, {})
-  ).toEqual( MESSAGE );
-});
-
-test('[FINDME-INPUT-MESSAGE-3] Read Message from Script Config',
-() => {
-  expect(
-    funlet.input.getMessage({}, {}, {message: MESSAGE})
-  ).toEqual( MESSAGE );
-});
-
-test('[FINDME-INPUT-MESSAGE-4] Read Default Message from Script Config',
-() => {
-  expect(
-    funlet.config.message( SPELLED_FROM_NUMBER )
-  ).toEqual( DEFAULT_MESSAGE );
-});
-
-test('[FINDME-INPUT-LANGUAGE-1] Read Language from Event',
-() => {
-  expect(
-    funlet.input.getLanguage({Language:FRENCH}, {}, {})
-  ).toEqual( FRENCH );
-});
-
-test('[FINDME-INPUT-LANGUAGE-2] Read Language from Environment',
-() => {
-  expect(
-    funlet.input.getLanguage({}, {FUNLET_FINDME_LANGUAGE:FRENCH}, {})
-  ).toEqual( FRENCH );
-});
-
-test('[FINDME-INPUT-LANGUAGE-3] Read Language from Script Config',
-() => {
-  expect(
-    funlet.input.getLanguage({}, {}, {language: FRENCH})
-  ).toEqual( FRENCH );
-});
-
-test('[FINDME-INPUT-LANGUAGE-4] Read Default Language from Script Config',
-() => {
-  expect( funlet.config.language ).toEqual( DEFAULT_LANGUAGE );
-});
-
-test('[FINDME-INPUT-VOICE-1] Read Voice from Event',
-() => {
-  expect(
-    funlet.input.getVoice({Voice:MAN}, {}, {})
-  ).toEqual( MAN );
-});
-
-test('[FINDME-INPUT-VOICE-2] Read Voice from Environment',
-() => {
-  expect(
-    funlet.input.getVoice({}, {FUNLET_FINDME_VOICE:WOMAN}, {})
-  ).toEqual( WOMAN );
-});
-
-test('[FINDME-INPUT-VOICE-3] Read Voice from Script Config',
-() => {
-  expect(
-    funlet.input.getVoice({}, {}, {voice: WOMAN})
-  ).toEqual( WOMAN );
-});
-
-test('[FINDME-INPUT-VOICE-4] Read Default Voice from Script Config',
-() => {
-  expect( funlet.config.voice ).toEqual( DEFAULT_VOICE );
-});
-
-test('[WHISPER-INPUT-HUMAN-CHECK-0] Read Human Check "1" from Event',
-() => {
-  expect(
-    funlet.input.isHumanCheckRequired({HumanCheck:"1"}, {}, {})
-  ).toEqual( true );
-});
-
-test('[FINDME-INPUT-HUMAN-CHECK-1] Read Human Check from Event',
-() => {
-  expect(
-    funlet.input.isHumanCheckRequired({HumanCheck:"true"}, {}, {})
-  ).toEqual( true );
-});
-
-test('[FINDME-INPUT-HUMAN-CHECK-2] Read Human Check from Environment',
-() => {
+test('[FINDME-INPUT-HUMAN-CHECK-2] Read Human Check from Environment', () => {
   expect(
     funlet.input.isHumanCheckRequired(
-      {}, {FUNLET_FINDME_HUMAN_CHECK:"true"}, {}
+      {},
+      { FUNLET_FINDME_HUMAN_CHECK: 'true' },
+      {}
     )
-  ).toEqual( true );
+  ).toEqual(true);
 });
 
-test('[FINDME-INPUT-HUMAN-CHECK-3] Read Human Check from Script Config',
-() => {
+test('[FINDME-INPUT-HUMAN-CHECK-3] Read Human Check from Script Config', () => {
   expect(
-    funlet.input.isHumanCheckRequired({}, {}, {humanCheck: true})
-  ).toEqual( true );
+    funlet.input.isHumanCheckRequired({}, {}, { humanCheck: true })
+  ).toEqual(true);
 });
 
-test('[FINDME-INPUT-HUMAN-CHECK-4] '+
-     'Read Default Human Check from Script Config',
-() => {
-  expect( funlet.config.humanCheck ).toEqual( DEFAULT_HUMAN_CHECK );
+test(
+  '[FINDME-INPUT-HUMAN-CHECK-4] ' +
+    'Read Default Human Check from Script Config',
+  () => {
+    expect(funlet.config.humanCheck).toEqual(DEFAULT_HUMAN_CHECK);
+  }
+);
+
+test('[FINDME-INPUT-DIGITS-0] Read No Digits from Event', () => {
+  expect(funlet.input.getDigits({}, {}, {})).toEqual(NO_DIGITS);
 });
 
-test('[FINDME-INPUT-DIGITS-0] Read No Digits from Event',
-() => {
+test('[FINDME-INPUT-DIGITS-1] Read Empty Digits from Event', () => {
+  expect(funlet.input.getDigits({ Digits: EMPTY_DIGITS }, {}, {})).toEqual(
+    EMPTY_DIGITS
+  );
+});
+
+test('[FINDME-INPUT-DIGITS-2] Read Non-Empty Digits from Event', () => {
+  expect(funlet.input.getDigits({ Digits: NON_EMPTY_DIGITS }, {}, {})).toEqual(
+    NON_EMPTY_DIGITS
+  );
+});
+
+test('[FINDME-INPUT-DIAL-0] Read No Dial from Event', () => {
+  expect(funlet.input.isDialDone({}, {}, {})).toEqual(DIAL_NOT_DONE);
+});
+
+test('[FINDME-INPUT-DIAL-1] Read Dial from Event', () => {
+  expect(funlet.input.isDialDone({ Dial: 'true' }, {}, {})).toEqual(DIAL_DONE);
+});
+
+test('[FINDME-INPUT-FALLBACK-URL-1] Read Fallback URL from Event', () => {
   expect(
-    funlet.input.getDigits({},{},{})
-  ).toEqual( NO_DIGITS );
+    funlet.input.getFallbackUrl({ FailUrl: FALLBACK_URL }, {}, {})
+  ).toEqual(FALLBACK_URL);
 });
 
-test('[FINDME-INPUT-DIGITS-1] Read Empty Digits from Event',
-() => {
-  expect(
-    funlet.input.getDigits({Digits:EMPTY_DIGITS}, {}, {})
-  ).toEqual( EMPTY_DIGITS );
-});
-
-test('[FINDME-INPUT-DIGITS-2] Read Non-Empty Digits from Event',
-() => {
-  expect(
-    funlet.input.getDigits({Digits:NON_EMPTY_DIGITS}, {}, {})
-  ).toEqual( NON_EMPTY_DIGITS );
-});
-
-test('[FINDME-INPUT-DIAL-0] Read No Dial from Event',
-() => {
-  expect(
-    funlet.input.isDialDone({}, {}, {})
-  ).toEqual( DIAL_NOT_DONE );
-});
-
-test('[FINDME-INPUT-DIAL-1] Read Dial from Event',
-() => {
-  expect(
-    funlet.input.isDialDone({Dial:"true"}, {}, {})
-  ).toEqual( DIAL_DONE );
-});
-
-test('[FINDME-INPUT-FALLBACK-URL-1] Read Fallback URL from Event',
-() => {
-  expect(
-    funlet.input.getFallbackUrl({FailUrl:FALLBACK_URL}, {}, {})
-  ).toEqual( FALLBACK_URL );
-});
-
-test('[FINDME-INPUT-FALLBACK-URL-2] Read Fallback URL from Environment',
-() => {
+test('[FINDME-INPUT-FALLBACK-URL-2] Read Fallback URL from Environment', () => {
   expect(
     funlet.input.getFallbackUrl(
-      {}, {FUNLET_FINDME_FALLBACK_URL:FALLBACK_URL}, {}
+      {},
+      { FUNLET_FINDME_FALLBACK_URL: FALLBACK_URL },
+      {}
     )
-  ).toEqual( FALLBACK_URL );
+  ).toEqual(FALLBACK_URL);
 });
 
-test('[FINDME-INPUT-FALLBACK-URL-3] Read Fallback URL from Script Config',
-() => {
+test('[FINDME-INPUT-FALLBACK-URL-3] Read Fallback URL from Script Config', () => {
   expect(
-    funlet.input.getFallbackUrl({}, {}, {fallbackUrl: FALLBACK_URL})
-  ).toEqual( FALLBACK_URL );
+    funlet.input.getFallbackUrl({}, {}, { fallbackUrl: FALLBACK_URL })
+  ).toEqual(FALLBACK_URL);
 });
 
-test('[FINDME-INPUT-FALLBACK-URL-4] Read Default Fallback URL from Script',
-() => {
-  expect( funlet.config.fallbackUrl ).toEqual( DEFAULT_FALLBACK_URL );
+test('[FINDME-INPUT-FALLBACK-URL-4] Read Default Fallback URL from Script', () => {
+  expect(funlet.config.fallbackUrl).toEqual(DEFAULT_FALLBACK_URL);
 });
 
-test('[FINDME-OUTPUT-FINDME-1-1] Find Me with 3 Phone Numbers',
-() => {
+test('[FINDME-OUTPUT-FINDME-1-1] Find Me with 3 Phone Numbers', () => {
   let response = new Twilio.twiml.VoiceResponse();
   funlet.output.findMeStage1(
     response,
-    [PHONE_NUMBER1,PHONE_NUMBER2,PHONE_NUMBER3],
-    DEFAULT_TIMEOUT, DEFAULT_WHISPER_URL, NO_FALLBACK_URL
+    [PHONE_NUMBER1, PHONE_NUMBER2, PHONE_NUMBER3],
+    DEFAULT_TIMEOUT,
+    DEFAULT_WHISPER_URL,
+    NO_FALLBACK_URL,
+    EXAMPLE_BASE_URL
   );
-  expect( response.toString() ).toEqual( FULL_RESPONSE_FIND_ME_1_1 );
+  expect(response.toString()).toEqual(FULL_RESPONSE_FIND_ME_1_1);
 });
 
-test('[FINDME-OUTPUT-FINDME-1-4] Allow up to 10 numbers',
-() => {
-  let response = new Twilio.twiml.VoiceResponse();
-  funlet.output.findMeStage1(
-    response,
-    [
-      PHONE_NUMBER1,PHONE_NUMBER2,PHONE_NUMBER3,PHONE_NUMBER4,PHONE_NUMBER5,
-      PHONE_NUMBER6,PHONE_NUMBER7,PHONE_NUMBER8,PHONE_NUMBER9,PHONE_NUMBER10
-    ],
-    DEFAULT_TIMEOUT, DEFAULT_WHISPER_URL, NO_FALLBACK_URL
-  );
-  expect( response.toString() ).toEqual( FULL_RESPONSE_FIND_ME_1_4 );
-});
-
-test('[FINDME-OUTPUT-FINDME-1-5] Discard Extra Numbers Above 10',
-() => {
+test('[FINDME-OUTPUT-FINDME-1-4] Allow up to 10 numbers', () => {
   let response = new Twilio.twiml.VoiceResponse();
   funlet.output.findMeStage1(
     response,
     [
-      PHONE_NUMBER1,PHONE_NUMBER2,PHONE_NUMBER3,PHONE_NUMBER4,PHONE_NUMBER5,
-      PHONE_NUMBER6,PHONE_NUMBER7,PHONE_NUMBER8,PHONE_NUMBER9,PHONE_NUMBER10,
-      PHONE_NUMBER11,PHONE_NUMBER12
+      PHONE_NUMBER1,
+      PHONE_NUMBER2,
+      PHONE_NUMBER3,
+      PHONE_NUMBER4,
+      PHONE_NUMBER5,
+      PHONE_NUMBER6,
+      PHONE_NUMBER7,
+      PHONE_NUMBER8,
+      PHONE_NUMBER9,
+      PHONE_NUMBER10,
     ],
-    DEFAULT_TIMEOUT, DEFAULT_WHISPER_URL, NO_FALLBACK_URL
+    DEFAULT_TIMEOUT,
+    DEFAULT_WHISPER_URL,
+    NO_FALLBACK_URL,
+    EXAMPLE_BASE_URL
   );
-  expect( response.toString() ).toEqual( FULL_RESPONSE_FIND_ME_1_5 );
+  expect(response.toString()).toEqual(FULL_RESPONSE_FIND_ME_1_4);
 });
 
-test('[FINDME-OUTPUT-FINDME-1-6] No More Numbers, Without Fallback URL',
-() => {
+test('[FINDME-OUTPUT-FINDME-1-5] Discard Extra Numbers Above 10', () => {
+  let response = new Twilio.twiml.VoiceResponse();
+  funlet.output.findMeStage1(
+    response,
+    [
+      PHONE_NUMBER1,
+      PHONE_NUMBER2,
+      PHONE_NUMBER3,
+      PHONE_NUMBER4,
+      PHONE_NUMBER5,
+      PHONE_NUMBER6,
+      PHONE_NUMBER7,
+      PHONE_NUMBER8,
+      PHONE_NUMBER9,
+      PHONE_NUMBER10,
+      PHONE_NUMBER11,
+      PHONE_NUMBER12,
+    ],
+    DEFAULT_TIMEOUT,
+    DEFAULT_WHISPER_URL,
+    NO_FALLBACK_URL,
+    EXAMPLE_BASE_URL
+  );
+  expect(response.toString()).toEqual(FULL_RESPONSE_FIND_ME_1_5);
+});
+
+test('[FINDME-OUTPUT-FINDME-1-6] No More Numbers, Without Fallback URL', () => {
   let response = new Twilio.twiml.VoiceResponse();
   funlet.output.findMeStage1(
     response,
     [],
-    DEFAULT_TIMEOUT, DEFAULT_WHISPER_URL, NO_FALLBACK_URL
+    DEFAULT_TIMEOUT,
+    DEFAULT_WHISPER_URL,
+    NO_FALLBACK_URL,
+    EXAMPLE_BASE_URL
   );
-  expect( response.toString() ).toEqual( FULL_RESPONSE_FIND_ME_1_6 );
+  expect(response.toString()).toEqual(FULL_RESPONSE_FIND_ME_1_6);
 });
 
-test('[FINDME-OUTPUT-FINDME-1-7] No More Numbers, With Fallback URL',
-() => {
+test('[FINDME-OUTPUT-FINDME-1-7] No More Numbers, With Fallback URL', () => {
   let response = new Twilio.twiml.VoiceResponse();
   funlet.output.findMeStage1(
     response,
     [],
-    DEFAULT_TIMEOUT, DEFAULT_WHISPER_URL, FALLBACK_URL
+    DEFAULT_TIMEOUT,
+    DEFAULT_WHISPER_URL,
+    FALLBACK_URL,
+    EXAMPLE_BASE_URL
   );
-  expect( response.toString() ).toEqual( FULL_RESPONSE_FIND_ME_1_7 );
+  expect(response.toString()).toEqual(FULL_RESPONSE_FIND_ME_1_7);
 });
 
-test('[FINDME-1-3] Find Me with Custom Timeout and Message', done => {
+test('[FINDME-1-3] Find Me with Custom Timeout and Message', (done) => {
   const callback = (err, result) => {
-    expect( result ).toBeInstanceOf( Twilio.twiml.VoiceResponse );
-    expect( result.toString() ).toEqual( FULL_RESPONSE_FIND_ME_1_3 );
+    expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+    expect(result.toString()).toEqual(FULL_RESPONSE_FIND_ME_1_3);
     done();
   };
-  funlet.handler({}, {
-    PhoneNumbers: [PHONE_NUMBER1,PHONE_NUMBER2,PHONE_NUMBER3],
-    Message: CUSTOM_MESSAGE, Timeout: TIMEOUT_STRING
-  }, callback);
+  funlet.handler(
+    EXAMPLE_CONTEXT,
+    {
+      PhoneNumbers: [PHONE_NUMBER1, PHONE_NUMBER2, PHONE_NUMBER3],
+      Message: CUSTOM_MESSAGE,
+      Timeout: TIMEOUT_STRING,
+    },
+    callback
+  );
 });
 
-test('[FINDME-2-1] Whisper: Recorded Message', done => {
+test('[FINDME-2-1] Whisper: Recorded Message', (done) => {
   const callback = (err, result) => {
-    expect( result ).toBeInstanceOf( Twilio.twiml.VoiceResponse );
-    expect( result.toString() ).toEqual( FULL_RESPONSE_FIND_ME_2_1 );
+    expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+    expect(result.toString()).toEqual(FULL_RESPONSE_FIND_ME_2_1);
     done();
   };
-  funlet.handler({}, {Whisper:"true",Message:RECORDED_MESSAGE}, callback);
+  funlet.handler(
+    EXAMPLE_CONTEXT,
+    { Whisper: 'true', Message: RECORDED_MESSAGE },
+    callback
+  );
 });
 
-test('[FINDME-3-1] Whisper: A Digit was Pressed', done => {
+test('[FINDME-3-1] Whisper: A Digit was Pressed', (done) => {
   const callback = (err, result) => {
-    expect( result ).toBeInstanceOf( Twilio.twiml.VoiceResponse );
-    expect( result.toString() ).toEqual( FULL_RESPONSE_FIND_ME_3_1 );
+    expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+    expect(result.toString()).toEqual(FULL_RESPONSE_FIND_ME_3_1);
     done();
   };
-  funlet.handler({}, {Digits:NON_EMPTY_DIGITS}, callback);
+  funlet.handler(
+    EXAMPLE_CONTEXT,
+    { Digits: NON_EMPTY_DIGITS, Whisper: 'true' },
+    callback
+  );
 });
 
-test('[FINDME-4-3] Failure with Fallback URL', done => {
+test('[FINDME-4-3] Failure with Fallback URL', (done) => {
   const callback = (err, result) => {
-    expect( result ).toBeInstanceOf( Twilio.twiml.VoiceResponse );
-    expect( result.toString() ).toEqual( FULL_RESPONSE_FIND_ME_4_3 );
+    expect(result).toBeInstanceOf(Twilio.twiml.VoiceResponse);
+    expect(result.toString()).toEqual(FULL_RESPONSE_FIND_ME_4_3);
     done();
   };
-  funlet.handler({}, {
-    Dial:"true", DialCallStatus:"busy", FailUrl:FALLBACK_URL
-  }, callback);
+  funlet.handler(
+    EXAMPLE_CONTEXT,
+    {
+      Dial: 'true',
+      DialCallStatus: 'busy',
+      FailUrl: FALLBACK_URL,
+    },
+    callback
+  );
 });
 
-afterAll( () =>
-  runtime.teardown()
-);
+afterAll(() => runtime.teardown());


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

Some of the changes were done by Prettier. The main changes I implemented:
- added a `getBaseUrl()` function that constructs the full base URL from the `context` since the relative `.` URL turned out to be flaky.
- adjust the appending of phone numbers in subsequent URLs to contain the index to mimic the original URL structure. Example: `PhoneNumbers[0]` instead of `PhoneNumbers[]`. 
- reformat `if` statement in main `handler` function to be a bit more readible
- change logic of `findMeStage4` to mimic original PHP code (fixed the main issue)
- add a `<Say>Connecting</Say>` to the `findMeStage3` if the user pressed a digit.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
