### PR TITLE
Ensure phone number var is specified in .env before querying for it

### DIFF
--- a/vaccine-standby/functions/setup.js
+++ b/vaccine-standby/functions/setup.js
@@ -23,6 +23,9 @@ exports.handler = async function (context, event, callback) {
 
   function getPhoneNumberSid() {
     return new Promise((resolve, reject) => {
+      if (typeof(context.TWILIO_PHONE_NUMBER) == 'undefined' || context.TWILIO_PHONE_NUMBER == '') {
+        throw new Error("TWILIO_PHONE_NUMBER is not set. You must set TWILIO_PHONE_NUMBER= in your .env file.");
+      }
       client.incomingPhoneNumbers
         .list({ phoneNumber: context.TWILIO_PHONE_NUMBER, limit: 20 })
         .then((incomingPhoneNumbers) => {


### PR DESCRIPTION
## Description

Ensure phone number is specified in .env before querying for it. Otherwise, the phone number query will return (and subsequently clobber!) the *first* phone number found in the account.

## Checklist

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

## Related issues
