### PR TITLE
feat(docs): Update sms-broadcast docs

### DIFF
--- a/sms-broadcast/.env
+++ b/sms-broadcast/.env
@@ -1,4 +1,4 @@
-# description: SID of your Twilio Notify Service
+# description: SID of your Twilio Notify Service (starts with IS)
 # format: sid
 # link: https://www.twilio.com/console/notify/services
 # required: true

--- a/sms-broadcast/README.md
+++ b/sms-broadcast/README.md
@@ -33,7 +33,7 @@ twilio plugins:install @twilio-labs/plugin-serverless
 3. Initiate a new project
 
 ```
-twilio serverless:init example --template=broadcast-sms && cd example
+twilio serverless:init example --template=sms-broadcast && cd example
 ```
 
 Before using this Function, you will need to create (or use an existing) Notify service and Messaging service. The Notify service will use the Messaging service to send out SMS messages. The Messaging service will be configured to send incoming messages to your Subscribe/Broadcast function.
@@ -78,8 +78,8 @@ Now if all went well, you'll be able to start using your phone number for managi
 
 Once the Function is deployed and your Twilio phone number is set up, folks can text anything to it to receive a brief informational message about what commands are available.
 
-* `subscribe` - subscribes the current number for updates from the service
-* `stop/start` - uses Twilio's built-in stop handling to opt a user out from, or back in to, receiving messages (check out this article for [further details on Twilio's built-in features for handling opt-out/in keywords](https://support.twilio.com/hc/en-us/articles/223134027-Twilio-support-for-opt-out-keywords-SMS-STOP-filtering-))
-* `broadcast <message content>` - Administrators can use the broadcast command to send a message out to all subscribed users. Not included in help text.
+- `subscribe` - subscribes the current number for updates from the service
+- `stop/start` - uses Twilio's built-in stop handling to opt a user out from, or back in to, receiving messages (check out this article for [further details on Twilio's built-in features for handling opt-out/in keywords](https://support.twilio.com/hc/en-us/articles/223134027-Twilio-support-for-opt-out-keywords-SMS-STOP-filtering-))
+- `broadcast <message content>` - Administrators can use the broadcast command to send a message out to all subscribed users. Not included in help text.
 
 To edit the copy for any of the messages, open the function code and look for the text strings at the top of the file.

--- a/sms-broadcast/README.md
+++ b/sms-broadcast/README.md
@@ -38,25 +38,19 @@ twilio serverless:init example --template=sms-broadcast && cd example
 
 Before using this Function, you will need to create (or use an existing) Notify service and Messaging service. The Notify service will use the Messaging service to send out SMS messages. The Messaging service will be configured to send incoming messages to your Subscribe/Broadcast function.
 
-### Create a Messaging Service
-
-Go to the console and [create a messaging service](https://www.twilio.com/console/sms/services). Choose the "Notifications, Two-way" use case to preset some options on the service.
-
-Once created, click on the left nav link for "Numbers" and add (or buy) a phone number to use with this service. This will be the phone number(s) your end users will interact with.
-
-We'll need to come back here later - consider leaving this page open in a tab while you proceed to the next step in the console.
-
 ### Create a Notify Service
 
 In the console, create a [Notify service](https://www.twilio.com/console/notify/services). Our function code uses Notify to store our subscriber list and to send out notifications. After your service is created, locate the Dropdown in your Notify service config labeled "Messaging Service SID". You should be able to choose the Messaging Service we created in the last step.
 
 You will need the generated SID for this service to configure your environment in the next step.
 
-Don't forget to save your changes!
+### Create a Messaging Service
+
+Once your [Notify service](https://www.twilio.com/console/notify/services) is created, go to its config page in the console and locate the Dropdown labeled "Messaging Service SID". Click the link next to that Dropdown labeled "Create a Messaging Service here". For the new Messaging Service's use case, choose "Not listed here". When prompted, add the phone number you want to use with this service to the Messaging Service's Sender Pool.
 
 ### Deploy the Function template
 
-Add the Notify Service SID to the `.env` file as `BROADCAST_NOTIFY_SERVICE_SID`. Add the phone numbers of admins that are permitted to send broadcast messages to the `.env` file as `BROADCAST_ADMIN_NUMBERS`.
+Add the Notify Service SID (which should start with `IS`) to the `.env` file as `BROADCAST_NOTIFY_SERVICE_SID`. Add the phone numbers of admins that are permitted to send broadcast messages to the `.env` file as `BROADCAST_ADMIN_NUMBERS`.
 
 Deploy your functions and assets with the following command. Note: you must run this command from inside your project folder. [More details in the docs.](https://www.twilio.com/docs/labs/serverless-toolkit)
 
@@ -70,7 +64,7 @@ In a few moments your Function should be deployed! Grab its URL from the results
 
 ### Handle incoming messages with your Function
 
-Go back to the [messaging service](https://www.twilio.com/console/sms/services) you created earlier. In its configuration, you'll see a checkbox for "Handle Incoming Messages". Click this box to enable the feature. In the text box that appears, paste in the URL to the Function we just deployed. Click "Save".
+Go back to the [messaging service](https://www.twilio.com/console/sms/services) you created earlier. In the sidebar, look for the Integration menu item. Under the Incoming Messages section of the Integration configuration page, you'll see a radio button for "Send a webhook". Click this radio button, and in the "Request URL" textbox that appears, paste the URL to the Function we just deployed. Click "Save".
 
 Now if all went well, you'll be able to start using your phone number for managing broadcasts and subscriptions!
 

--- a/sms-broadcast/assets/index.html
+++ b/sms-broadcast/assets/index.html
@@ -49,6 +49,19 @@
                     </p>
                     <p>This app allows you to broadcast SMS messages to large numbers of people.</p>
                     <ol class="steps">
+                        <li>
+                            In the Twilio Console page for your Notify Service, create a new Messaging
+                            Service with use case <b>Not listed here</b>, and add your Twilio phone number
+                            to its sender pool
+                        </li>
+                        <li>
+                            Under the <b>Integration</b> tab, select <b>Send a webhook</b>, and enter the
+                            below webhook URL as its <b>Request URL</b>
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/broadcast">
+                            </form>
+                        </li>
                         <li>Text anything to your Twilio phone number</li>
                         <li>
                             You should receive a response saying "Hello! Text "subscribe" to receive updates,
@@ -75,22 +88,17 @@
                 <section>
                     <h2>Troubleshooting</h2>
                     <ul>
-                        <li>
-                            Check the
-                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
-                               target="_blank"
-                               rel="noopener">
-                                phone number configuration
-                            </a>
-                            and make sure the Twilio phone number you want for your app has a SMS webhook
-                            configured to point at the following URL
-                            <form>
-                                <label for="twilio-webhook">Webhook URL</label>
-                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/broadcast">
-                            </form>
-                        </li>
                         <li><p>Make sure you have set up the Notify Service and Messaging Service correctly.</p></li>
-                        <li><p>Ensure that the Messaging Service is set up to handle incoming messages.</p></li>
+                        <li>
+                            <p>
+                                Ensure that the Messaging Service is set up to send a webhook in response to incoming
+                                messages, with the request URL set to the following
+                                <form>
+                                    <label for="twilio-webhook">Webhook URL</label>
+                                    <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/broadcast">
+                                </form>
+                            </p>
+                        </li>
                         <li>
                             <p>
                                 If you cannot send broadcasts, make sure your message starts with the "broadcast"

--- a/sms-broadcast/assets/index.html
+++ b/sms-broadcast/assets/index.html
@@ -50,8 +50,13 @@
                     <p>This app allows you to broadcast SMS messages to large numbers of people.</p>
                     <ol class="steps">
                         <li>
-                            In the Twilio Console page for your Notify Service, create a new Messaging
-                            Service with use case <b>Not listed here</b>, and add your Twilio phone number
+                            In the Twilio Console page for your Notify Service,
+                            <a href="https://www.twilio.com/console/notify/services"
+                               target="_blank"
+                               rel="noopener">
+                                create a new Messaging Service
+                            </a>
+                            with use case <b>Not listed here</b>, and add your Twilio phone number
                             to its sender pool
                         </li>
                         <li>


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

Updates the docs for `sms-broadcast` to reflect the modern Twilio Console UI. I couldn't find a stable URL that links directly to the Twilio Console page for the Notify service, so let me know if there's a good option to link straight to that from `index.html`.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
