### PR TITLE
Make Funlets Quick Deployable

### DIFF
--- a/funlet-call-me/.env
+++ b/funlet-call-me/.env
@@ -1,3 +1,9 @@
+# description: Calls made to your Twilio number will get forwarded to this E.164-formatted phone number
+# format: phone_number
+# required: true
+# link: https://www.twilio.com/docs/glossary/what-e164
+FUNLET_CALLME_PHONE_NUMBER=+12223334444
+
 # description: The path to the webhook
 # configurable: false
 TWILIO_VOICE_WEBHOOK_URL=/funlet-call-me

--- a/funlet-call-me/assets/index.html
+++ b/funlet-call-me/assets/index.html
@@ -15,6 +15,11 @@
              inputPrependBaseURL();
          });
         </script>
+        <style>
+         thead {
+             text-align: left;
+         }
+        </style>
     </head>
     <body>
         <div class="page-top">
@@ -67,6 +72,40 @@
                             section of its source code using the "Edit this code" button below
                         </li>
                     </ol>
+                    <p>
+                        The following URL parameters may be sent to this Funlet to override the defaults it was
+                        configured to use:
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Attribute Name</th>
+                                    <th>Allowed Values</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>PhoneNumber</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>FailUrl</td>
+                                    <td>Any Url</td>
+                                </tr>
+                                <tr>
+                                    <td>Message</td>
+                                    <td>
+                                        A URL or a string to play or read to the person who answers the second leg
+                                        of the phone call. It should tell them to press any key to accept the call.
+                                        If not provided, a default message will be played.
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Timeout</td>
+                                    <td>How long, in seconds, should the phone be allowed to ring.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </p>
                 </section>
 
                 <section>

--- a/funlet-call-me/assets/index.html
+++ b/funlet-call-me/assets/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
+
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This Twilio Function will forward calls from your Twilio phone number
+                        to another phone number of your choice. When that number answers,
+                        the person answering will be prompted to press a key to accept the call. It
+                        is based on the
+                        <a href="https://www.twilio.com/labs/twimlets/callme"
+                           target="_blank"
+                           rel="noopener">
+                            Twimlet named <code>callme</code>
+                        </a>, and may be used as its drop-in replacement.
+                    </p>
+                    <ol class="steps">
+                        <li>Call your Twilio phone number </li>
+                        <li>You should receive a call on the number you have provided as a forwarding number.</li>
+                        <li>
+                            To configure various additional features of this Function, reference the Configuration
+                            section of its source code using the "Edit this code" button below
+                        </li>
+                    </ol>
+                </section>
+
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                               target="_blank"
+                               rel="noopener">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a voice webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/funlet-call-me">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
+</html>

--- a/funlet-echo/.env
+++ b/funlet-echo/.env
@@ -1,7 +1,7 @@
 # description: The default TwiML to echo back (can be overridden by the Twiml URL parameter)
 # format: text
 # link: https://www.twilio.com/docs/voice/twiml
-FUNLET_ECHO_TWIML="<Response><Say>Hello, world!</Say></Response>"
+FUNLET_ECHO_TWIML=<Response><Say>Hello, world!</Say></Response>
 
 # description: The path to the webhook
 # configurable: false

--- a/funlet-echo/.env
+++ b/funlet-echo/.env
@@ -1,3 +1,8 @@
+# description: The default TwiML to echo back (can be overridden by the Twiml URL parameter)
+# format: text
+# link: https://www.twilio.com/docs/voice/twiml
+FUNLET_ECHO_TWIML="<Response><Say>Hello, world!</Say></Response>"
+
 # description: The path to the webhook
 # configurable: false
 TWILIO_VOICE_WEBHOOK_URL=/funlet-echo

--- a/funlet-echo/assets/index.html
+++ b/funlet-echo/assets/index.html
@@ -15,6 +15,11 @@
              inputPrependBaseURL();
          });
         </script>
+        <style>
+         thead {
+             text-align: left;
+         }
+        </style>
     </head>
     <body>
         <div class="page-top">
@@ -68,6 +73,32 @@
                         <li>Call your Twilio phone number </li>
                         <li>You should hear the result of your TwiML</li>
                     </ol>
+                    <p>
+                        The following URL parameters may be sent to this Funlet to override the defaults it was
+                        configured to use:
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Attribute Name</th>
+                                    <th>Allowed Values</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Twiml</td>
+                                    <td>
+                                        A chunk of
+                                        <a href="https://www.twilio.com/docs/api/twiml"
+                                           target="_blank"
+                                           rel="noopener">
+                                            TwiML
+                                        </a>
+                                        to echo back. Remember to URL encode the TwiML.
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </p>
                 </section>
 
                 <section>

--- a/funlet-echo/assets/index.html
+++ b/funlet-echo/assets/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
+
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This Twilio Function will echo back a string of
+                        <a href="https://www.twilio.com/docs/voice/twiml"
+                           target="_blank"
+                           rel="noopenr">
+                            TwiML
+                        </a>
+                        in response to a request. The TwiML that gets echoed back can be changed
+                        dynamically using the <code>Twiml</code> URL parameter. This Function is
+                        based on the
+                        <a href="https://www.twilio.com/labs/twimlets/echo"
+                           target="_blank"
+                           rel="noopener">
+                            Twimlet named <code>echo</code>
+                        </a>, and may be used as its drop-in replacement.
+                    </p>
+                    <ol class="steps">
+                        <li>Call your Twilio phone number </li>
+                        <li>You should hear the result of your TwiML</li>
+                    </ol>
+                </section>
+
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                               target="_blank"
+                               rel="noopener">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a voice webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/funlet-echo">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
+</html>

--- a/funlet-find-me/.env
+++ b/funlet-find-me/.env
@@ -2,7 +2,7 @@
 # format: list(phone_number)
 # required: true
 # link: https://www.twilio.com/docs/glossary/what-e164
-FUNLET_FINDME_PHONE_NUMBERS="+12125551234,+17025556789"
+FUNLET_FINDME_PHONE_NUMBERS="+12345551234,+12345556789"
 
 # description: The path to the webhook
 # configurable: false

--- a/funlet-find-me/.env
+++ b/funlet-find-me/.env
@@ -1,3 +1,9 @@
+# description: The phone numbers in this comma-separated list will be called in order. All phone numbers must follow the E.164 format
+# format: list(phone_number)
+# required: true
+# link: https://www.twilio.com/docs/glossary/what-e164
+FUNLET_FINDME_PHONE_NUMBERS="+12125551234,+17025556789"
+
 # description: The path to the webhook
 # configurable: false
 TWILIO_VOICE_WEBHOOK_URL=/funlet-find-me

--- a/funlet-find-me/assets/index.html
+++ b/funlet-find-me/assets/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
+
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This Twilio Function will call a list of phone numbers in order, until
+                        one of them picks up. It is based on the
+                        <a href="https://www.twilio.com/labs/twimlets/findme"
+                           target="_blank"
+                           rel="noopener">
+                            Twimlet named <code>findme</code>
+                        </a>, and may be used as its drop-in replacement.
+                    </p>
+                    <ol class="steps">
+                        <li>Call your Twilio phone number </li>
+                        <li>
+                            Each phone number you entered will be called in order, until one picks up.
+                        </li>
+                        <li>
+                            To configure various additional features of this Function, reference the Configuration
+                            section of its source code using the "Edit this code" button below
+                        </li>
+                    </ol>
+                </section>
+
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                               target="_blank"
+                               rel="noopener">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a voice webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/funlet-find-me">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
+</html>

--- a/funlet-find-me/assets/index.html
+++ b/funlet-find-me/assets/index.html
@@ -15,6 +15,11 @@
              inputPrependBaseURL();
          });
         </script>
+        <style>
+         thead {
+             text-align: left;
+         }
+        </style>
     </head>
     <body>
         <div class="page-top">
@@ -67,6 +72,76 @@
                             section of its source code using the "Edit this code" button below
                         </li>
                     </ol>
+                    <p>
+                        The following URL parameters may be sent to this Funlet to override the defaults it was
+                        configured to use:
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Attribute Name</th>
+                                    <th>Allowed Values</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>PhoneNumbers[0]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>PhoneNumbers[1]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>PhoneNumbers[2]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>PhoneNumbers[3]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>PhoneNumbers[4]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>PhoneNumbers[5]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>PhoneNumbers[6]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>PhoneNumbers[7]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>PhoneNumbers[8]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>PhoneNumbers[9]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>FailUrl</td>
+                                    <td>Any URL</td>
+                                </tr>
+                                <tr>
+                                    <td>Message</td>
+                                    <td>
+                                        A URL or a string to play or read to the person who answers the
+                                        second leg of the phone call. It should tell them to press any key
+                                        to accept the call. If not provided, a default message will be played.
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Timeout</td>
+                                    <td>How long, in seconds, should the phone be allowed to ring.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </p>
                 </section>
 
                 <section>

--- a/funlet-find-me/functions/funlet-find-me.js
+++ b/funlet-find-me/functions/funlet-find-me.js
@@ -134,6 +134,12 @@ function getPhoneNumbers(params, env, config) {
 
   readListParam('PhoneNumbers', params).forEach(addIfNotEmpty);
   readEnvList('FUNLET_FINDME_PHONE_NUMBER', 1, 5, env).forEach(addIfNotEmpty);
+  if(env.FUNLET_FINDME_PHONE_NUMBERS) {
+    env.FUNLET_FINDME_PHONE_NUMBERS
+           .split(',')
+           .filter(s => s.trim())
+           .forEach(addIfNotEmpty);
+  }
 
   if (Array.isArray(config.phoneNumbers)) {
     config.phoneNumbers.forEach(addIfNotEmpty);

--- a/funlet-forward/.env
+++ b/funlet-forward/.env
@@ -1,3 +1,9 @@
+# description: Calls made to your Twilio number will get forwarded to this E.164-formatted phone number
+# format: phone_number
+# required: true
+# link: https://www.twilio.com/docs/glossary/what-e164
+FUNLET_FORWARD_PHONE_NUMBER=+12223334444
+
 # description: The path to the webhook
 # configurable: false
 TWILIO_VOICE_WEBHOOK_URL=/funlet-forward

--- a/funlet-forward/assets/index.html
+++ b/funlet-forward/assets/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
+
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This Twilio Function forwards calls from your Twilio phone number to another
+                        number of your choice. It is based on the
+                        <a href="https://www.twilio.com/labs/twimlets/forward"
+                           target="_blank"
+                           rel="noopener">
+                            Twimlet named <code>forward</code>
+                        </a>, and may be used as its drop-in replacement.
+                    </p>
+                    <ol class="steps">
+                        <li>Call your Twilio phone number </li>
+                        <li>You should receive a call on the number you have provided as a forwarding number.</li>
+                        <li>
+                            To configure various additional features of this Function, reference the Configuration
+                            section of its source code using the "Edit this code" button below
+                        </li>
+                    </ol>
+                </section>
+
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                               target="_blank"
+                               rel="noopener">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a voice webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/funlet-forward">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
+</html>

--- a/funlet-forward/assets/index.html
+++ b/funlet-forward/assets/index.html
@@ -15,6 +15,11 @@
              inputPrependBaseURL();
          });
         </script>
+        <style>
+         thead {
+             text-align: left;
+         }
+        </style>
     </head>
     <body>
         <div class="page-top">
@@ -65,6 +70,59 @@
                             section of its source code using the "Edit this code" button below
                         </li>
                     </ol>
+                    <p>
+                        The following URL parameters may be sent to this Funlet to override the defaults it was
+                        configured to use:
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Attribute Name</th>
+                                    <th>Allowed Values</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>PhoneNumber</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>CallerId</td>
+                                    <td>
+                                        The phone number you'd like to appear as the Caller ID when forwarding. Must
+                                        be a Twilio phone number or a verified number.
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>FailUrl</td>
+                                    <td>Any URL</td>
+                                </tr>
+                                <tr>
+                                    <td>Timeout</td>
+                                    <td>How long, in seconds, should the phone be allowed to ring.</td>
+                                </tr>
+                                <tr>
+                                    <td>AllowedCallers[0]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>AllowedCallers[1]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>AllowedCallers[2]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>AllowedCallers[3]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>AllowedCallers[4]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </p>
                 </section>
 
                 <section>

--- a/funlet-simple-menu/.env
+++ b/funlet-simple-menu/.env
@@ -1,3 +1,8 @@
+# description: The URL of a media file to <Play>, or a string to <Say>, to greet the caller. Can be overridden by the Message URL parameter.
+# format: text
+# required: true
+FUNLET_MENU_MESSAGE=Hello! Please select an option.
+
 # description: The path to the webhook
 # configurable: false
 TWILIO_VOICE_WEBHOOK_URL=/funlet-simple-menu

--- a/funlet-simple-menu/assets/index.html
+++ b/funlet-simple-menu/assets/index.html
@@ -15,6 +15,11 @@
              inputPrependBaseURL();
          });
         </script>
+        <style>
+         thead {
+             text-align: left;
+         }
+        </style>
     </head>
     <body>
         <div class="page-top">
@@ -78,6 +83,34 @@
                             for that menu option
                         </li>
                     </ol>
+                    <p>
+                        The following URL parameters may be sent to this Funlet to override the defaults it was
+                        configured to use:
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Attribute Name</th>
+                                    <th>Allowed Values</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Message</td>
+                                    <td>
+                                        The URL of a media file to &lt;Play&gt;, or a string to &lt;Say&gt; to
+                                        greet the caller.
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Options[n]</td>
+                                    <td>
+                                        The URL to which call flow should be directed, if n is pressed. See
+                                        examples below.
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </p>
                 </section>
 
                 <section>

--- a/funlet-simple-menu/assets/index.html
+++ b/funlet-simple-menu/assets/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
+
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This Twilio Function will play a greeting and wait for the caller to press
+                        one or more digits on their keypad. Based on what was pressed, call flow is
+                        directed to a specific URL (which can be another Function). This Function is
+                        based on the
+                        <a href="https://www.twilio.com/labs/twimlets/menu"
+                           target="_blank"
+                           rel="noopener">
+                            Twimlet named <code>menu</code>
+                        </a>, and may be used as its drop-in replacement.
+                    </p>
+                    <ol class="steps">
+                        <li>
+                            Open this Function's source code with the "Edit this code" button below
+                        </li>
+                        <li>
+                            Find the Configuration section, go to the definition for the
+                            <code>options</code> configuration variable, and follow the comment
+                            above its definition to define a menu
+                        </li>
+                        <li>Call your Twilio phone number </li>
+                        <li>
+                            You should hear your greeting, followed by the phone menu you configured
+                            above
+                        </li>
+                        <li>
+                            Press a digit, and your call flow will be redirected to the URL you chose
+                            for that menu option
+                        </li>
+                    </ol>
+                </section>
+
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                               target="_blank"
+                               rel="noopener">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a voice webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/funlet-simple-menu">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
+</html>

--- a/funlet-simple-message/.env
+++ b/funlet-simple-message/.env
@@ -1,3 +1,24 @@
+# description: The first URL to <Play>, or string to <Say>.
+# format: text
+# required: true
+FUNLET_MESSAGE1=Hello, world!
+
+# description: The second URL to <Play>, or string to <Say>.
+# format: text
+FU1LET_MESSAGE2=
+
+# description: The third URL to <Play>, or string to <Say>.
+# format: text
+FU1LET_MESSAGE3=
+
+# description: The fourth URL to <Play>, or string to <Say>.
+# format: text
+FU1LET_MESSAGE4=
+
+# description: The fifth URL to <Play>, or string to <Say>.
+# format: text
+FU1LET_MESSAGE5=
+
 # description: The path to the webhook
 # configurable: false
 TWILIO_VOICE_WEBHOOK_URL=/funlet-simple-message

--- a/funlet-simple-message/.env
+++ b/funlet-simple-message/.env
@@ -1,23 +1,23 @@
 # description: The first URL to <Play>, or string to <Say>.
 # format: text
 # required: true
-FUNLET_MESSAGE1=Hello, world!
+FUNLET_MESSAGE_1=Hello, world!
 
 # description: The second URL to <Play>, or string to <Say>.
 # format: text
-FU1LET_MESSAGE2=
+FUNLET_MESSAGE_2=
 
 # description: The third URL to <Play>, or string to <Say>.
 # format: text
-FU1LET_MESSAGE3=
+FUNLET_MESSAGE_3=
 
 # description: The fourth URL to <Play>, or string to <Say>.
 # format: text
-FU1LET_MESSAGE4=
+FUNLET_MESSAGE_4=
 
 # description: The fifth URL to <Play>, or string to <Say>.
 # format: text
-FU1LET_MESSAGE5=
+FUNLET_MESSAGE_5=
 
 # description: The path to the webhook
 # configurable: false

--- a/funlet-simple-message/assets/index.html
+++ b/funlet-simple-message/assets/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
+
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This Twilio Function will play one or more greetings to the caller. Each
+                        greeting can be the URL to a media file to play, or a string that will be
+                        vocalized. This Function is based on the
+                        <a href="https://www.twilio.com/labs/twimlets/message"
+                           target="_blank"
+                           rel="noopener">
+                            Twimlet named <code>message</code>
+                        </a>, and may be used as its drop-in replacement.
+                    </p>
+                    <ol class="steps">
+                        <li>Call your Twilio phone number </li>
+                        <li>You should hear each of your greetings in order</li>
+                    </ol>
+                </section>
+
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                               target="_blank"
+                               rel="noopener">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a voice webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/funlet-simple-message">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
+</html>

--- a/funlet-simple-message/assets/index.html
+++ b/funlet-simple-message/assets/index.html
@@ -15,6 +15,11 @@
              inputPrependBaseURL();
          });
         </script>
+        <style>
+         thead {
+             text-align: left;
+         }
+        </style>
     </head>
     <body>
         <div class="page-top">
@@ -62,6 +67,38 @@
                         <li>Call your Twilio phone number </li>
                         <li>You should hear each of your greetings in order</li>
                     </ol>
+                    <p>
+                        The following URL parameters may be sent to this Funlet to override the defaults it was
+                        configured to use:
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Attribute Name</th>
+                                    <th>Allowed Values</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>Message[0]</td>
+                                    <td>
+                                        The URL of a media file to &lt;Play&gt;, or a string to &lt;Say&gt;
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Message[1]</td>
+                                    <td>
+                                        The URL of a media file to &lt;Play&gt;, or a string to &lt;Say&gt;
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Message[n]</td>
+                                    <td>
+                                        The URL of a media file to &lt;Play&gt;, or a string to &lt;Say&gt;
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </p>
                 </section>
 
                 <section>

--- a/funlet-simulring/.env
+++ b/funlet-simulring/.env
@@ -1,3 +1,9 @@
+# description: The phone numbers in this comma-separated list will be called simultaneously. All phone numbers must follow the E.164 format
+# format: list(phone_number)
+# required: true
+# link: https://www.twilio.com/docs/glossary/what-e164
+FUNLET_SIMULRING_PHONE_NUMBERS="+12125551234,+17025556789"
+
 # description: The path to the webhook
 # configurable: false
 TWILIO_VOICE_WEBHOOK_URL=/funlet-simulring

--- a/funlet-simulring/.env
+++ b/funlet-simulring/.env
@@ -2,7 +2,7 @@
 # format: list(phone_number)
 # required: true
 # link: https://www.twilio.com/docs/glossary/what-e164
-FUNLET_SIMULRING_PHONE_NUMBERS="+12125551234,+17025556789"
+FUNLET_SIMULRING_PHONE_NUMBERS="+12345551234,+12345556789"
 
 # description: The path to the webhook
 # configurable: false

--- a/funlet-simulring/assets/index.html
+++ b/funlet-simulring/assets/index.html
@@ -15,6 +15,11 @@
              inputPrependBaseURL();
          });
         </script>
+        <style>
+         thead {
+             text-align: left;
+         }
+        </style>
     </head>
     <body>
         <div class="page-top">
@@ -64,6 +69,56 @@
                         <li>If one of the numbers picks up, you should be connected to them</li>
 
                     </ol>
+                    <p>
+                        The following URL parameters may be sent to this Funlet to override the defaults it was
+                        configured to use:
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Attribute Name</th>
+                                    <th>Allowed Values</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>PhoneNumbers[0]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>PhoneNumbers[1]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>PhoneNumbers[2]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>PhoneNumbers[3]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>PhoneNumbers[4]</td>
+                                    <td>Any 10 digit phone number</td>
+                                </tr>
+                                <tr>
+                                    <td>FailUrl</td>
+                                    <td>Any URL</td>
+                                </tr>
+                                <tr>
+                                    <td>Message</td>
+                                    <td>
+                                        A URL or a string to play or read to the person who answers the
+                                        second leg of the phone call. It should tell them to press any key
+                                        to accept the call. If not provided, a default message will be played.
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>Timeout</td>
+                                    <td>How long, in seconds, should the phone be allowed to ring.</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </p>
                 </section>
 
                 <section>

--- a/funlet-simulring/assets/index.html
+++ b/funlet-simulring/assets/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
+
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This Twilio Function will dial two or more phone numbers simultaneously, and
+                        the first person to answer is connected to the caller. This Function is
+                        based on the
+                        <a href="https://www.twilio.com/labs/twimlets/simulring"
+                           target="_blank"
+                           rel="noopener">
+                            Twimlet named <code>simulring</code>
+                        </a>, and may be used as its drop-in replacement.
+                    </p>
+                    <ol class="steps">
+                        <li>Call your Twilio phone number </li>
+                        <li>All of the numbers you configured should ring</li>
+                        <li>If one of the numbers picks up, you should be connected to them</li>
+
+                    </ol>
+                </section>
+
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                               target="_blank"
+                               rel="noopener">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a voice webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/funlet-simulring">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
+</html>

--- a/funlet-simulring/functions/funlet-simulring.js
+++ b/funlet-simulring/functions/funlet-simulring.js
@@ -136,6 +136,12 @@ function getPhoneNumbers(params, env, config) {
     .forEach( addIfNotEmpty );
   readEnvList( "FUNLET_SIMULRING_PHONE_NUMBER", 1, 5, env )
     .forEach( addIfNotEmpty );
+  if(env.FUNLET_SIMULRING_PHONE_NUMBERS) {
+    env.FUNLET_FINDME_PHONE_NUMBERS
+           .split(',')
+           .filter(s => s.trim())
+           .forEach(addIfNotEmpty);
+  }
 
   if ( Array.isArray(config.phoneNumbers) ) {
     config.phoneNumbers.forEach( addIfNotEmpty );

--- a/funlet-whisper/.env
+++ b/funlet-whisper/.env
@@ -1,3 +1,7 @@
+# description: If "true", check that the recipient is human by having them press a button.
+# format: text
+FUNLET_WHISPER_HUMAN_CHECK=false
+
 # description: The path to the webhook
 # configurable: false
 TWILIO_VOICE_WEBHOOK_URL=/funlet-whisper

--- a/funlet-whisper/assets/index.html
+++ b/funlet-whisper/assets/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Get started with your Twilio Functions!</title>
+
+        <link rel="icon" href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico">
+        <link rel="stylesheet" href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css">
+
+        <script src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js" defer></script>
+        <script>
+         window.addEventListener('DOMContentLoaded', (_event) => {
+             inputPrependBaseURL();
+         });
+        </script>
+    </head>
+    <body>
+        <div class="page-top">
+            <header>
+                <div id="twilio-logo">
+                    <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+                        <svg class="logo" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 60 60">
+                            <title>Twilio Logo</title><path class="cls-1" d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"/></svg>
+                    </a>
+                </div>
+                <nav>
+                    <span>Your Twilio application</span>
+                    <aside>
+                        <svg class="icon" role="img" aria-hidden="true" width="100%" height="100%" viewBox="0 0 20 20" aria-labelledby="NewIcon-1577"><path fill="currentColor" fill-rule="evenodd" d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"></path></svg>
+                        Live
+                    </aside>
+                </nav>
+            </header>
+        </div>
+        <main>
+            <div class="content">
+                <h1>
+                    <img src="https://twilio-labs.github.io/function-templates/static/v1/success.svg" />
+                    <div>
+                        <p>Welcome!</p>
+                        <p>Your live application with Twilio is ready to use!</p>
+                    </div>
+                </h1>
+                <section>
+                    <h2>Get started with your application</h2>
+                    <p>
+                        Now that your code is deployed, here are the last steps you need to do to finish your app.
+                    </p>
+                    <p>
+                        This Twilio Function will say a message and request to press a digit
+                        to check that the caller is human, and not a voicemail. If the check is
+                        requested and no digits are pressed, hang up.
+                        This Function is based on the undocumented <code>whisper.php</code> Twimlet,
+                        and may be used as its drop-in replacement.
+                    </p>
+                    <ol class="steps">
+                        <li>Call your Twilio phone number</li>
+                        <li>If you have the human check enabled, press a digit to connect the call</li>
+                    </ol>
+                </section>
+
+                <section>
+                    <!-- APP_INFO_V2 -->
+                </section>
+                <section>
+                    <h2>Troubleshooting</h2>
+                    <ul>
+                        <li>
+                            Check the
+                            <a href="https://www.twilio.com/console/phone-numbers/incoming"
+                               target="_blank"
+                               rel="noopener">
+                                phone number configuration
+                            </a>
+                            and make sure the Twilio phone number you want for your app has a voice webhook
+                            configured to point at the following URL
+                            <form>
+                                <label for="twilio-webhook">Webhook URL</label>
+                                <input type="text" id="twilio-webhook" class="function-root" readonly=true value="/funlet-whisper">
+                            </form>
+                        </li>
+                    </ul>
+                </section>
+            </div>
+        </main>
+        <footer>
+            <span class="statement">We can't wait to see what you build.</span>
+        </footer>
+    </body>
+</html>

--- a/test/all-templates.test.js
+++ b/test/all-templates.test.js
@@ -9,8 +9,7 @@ const { parser } = require('configure-env');
 
 // skipList is a list of function templates that don't pass verification
 // for now, but will in the long term
-const skipList = ['conversations', 'funlet-echo',
-                  'funlet-find-me', 'funlet-simple-menu',
+const skipList = ['conversations', 'funlet-find-me', 'funlet-simple-menu',
                   'funlet-simple-message', 'funlet-simulring',
                   'funlet-whisper', 'vaccine-standby'];
 const excludedPaths = ['node_modules', 'test', 'coverage', 'docs', 'blank'] + skipList;

--- a/test/all-templates.test.js
+++ b/test/all-templates.test.js
@@ -9,7 +9,7 @@ const { parser } = require('configure-env');
 
 // skipList is a list of function templates that don't pass verification
 // for now, but will in the long term
-const skipList = ['conversations', 'funlet-whisper', 'vaccine-standby'];
+const skipList = ['conversations', 'vaccine-standby'];
 const excludedPaths = ['node_modules', 'test', 'coverage', 'docs', 'blank'] + skipList;
 const projectRoot = path.resolve(__dirname, '..');
 // Assemble a list of template directories here, since templates.json

--- a/test/all-templates.test.js
+++ b/test/all-templates.test.js
@@ -9,7 +9,7 @@ const { parser } = require('configure-env');
 
 // skipList is a list of function templates that don't pass verification
 // for now, but will in the long term
-const skipList = ['conversations', 'funlet-simple-menu',
+const skipList = ['conversations',
                   'funlet-simple-message', 'funlet-simulring',
                   'funlet-whisper', 'vaccine-standby'];
 const excludedPaths = ['node_modules', 'test', 'coverage', 'docs', 'blank'] + skipList;

--- a/test/all-templates.test.js
+++ b/test/all-templates.test.js
@@ -9,8 +9,7 @@ const { parser } = require('configure-env');
 
 // skipList is a list of function templates that don't pass verification
 // for now, but will in the long term
-const skipList = ['conversations',
-                  'funlet-simple-message', 'funlet-simulring',
+const skipList = ['conversations', 'funlet-simulring',
                   'funlet-whisper', 'vaccine-standby'];
 const excludedPaths = ['node_modules', 'test', 'coverage', 'docs', 'blank'] + skipList;
 const projectRoot = path.resolve(__dirname, '..');

--- a/test/all-templates.test.js
+++ b/test/all-templates.test.js
@@ -9,7 +9,7 @@ const { parser } = require('configure-env');
 
 // skipList is a list of function templates that don't pass verification
 // for now, but will in the long term
-const skipList = ['conversations', 'funlet-call-me', 'funlet-echo',
+const skipList = ['conversations', 'funlet-echo',
                   'funlet-find-me', 'funlet-simple-menu',
                   'funlet-simple-message', 'funlet-simulring',
                   'funlet-whisper', 'vaccine-standby'];

--- a/test/all-templates.test.js
+++ b/test/all-templates.test.js
@@ -9,7 +9,7 @@ const { parser } = require('configure-env');
 
 // skipList is a list of function templates that don't pass verification
 // for now, but will in the long term
-const skipList = ['conversations', 'funlet-find-me', 'funlet-simple-menu',
+const skipList = ['conversations', 'funlet-simple-menu',
                   'funlet-simple-message', 'funlet-simulring',
                   'funlet-whisper', 'vaccine-standby'];
 const excludedPaths = ['node_modules', 'test', 'coverage', 'docs', 'blank'] + skipList;

--- a/test/all-templates.test.js
+++ b/test/all-templates.test.js
@@ -10,7 +10,7 @@ const { parser } = require('configure-env');
 // skipList is a list of function templates that don't pass verification
 // for now, but will in the long term
 const skipList = ['conversations', 'funlet-call-me', 'funlet-echo',
-                  'funlet-find-me', 'funlet-forward', 'funlet-simple-menu',
+                  'funlet-find-me', 'funlet-simple-menu',
                   'funlet-simple-message', 'funlet-simulring',
                   'funlet-whisper', 'vaccine-standby'];
 const excludedPaths = ['node_modules', 'test', 'coverage', 'docs', 'blank'] + skipList;

--- a/test/all-templates.test.js
+++ b/test/all-templates.test.js
@@ -9,8 +9,7 @@ const { parser } = require('configure-env');
 
 // skipList is a list of function templates that don't pass verification
 // for now, but will in the long term
-const skipList = ['conversations', 'funlet-simulring',
-                  'funlet-whisper', 'vaccine-standby'];
+const skipList = ['conversations', 'funlet-whisper', 'vaccine-standby'];
 const excludedPaths = ['node_modules', 'test', 'coverage', 'docs', 'blank'] + skipList;
 const projectRoot = path.resolve(__dirname, '..');
 // Assemble a list of template directories here, since templates.json


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

This PR makes the `funlet-*` templates Quick Deployable. For most funlets, this just involves writing an `index.html` and mapping the funlet's configuration variables to `.env` variables. `funlet-find-me` and `funlet-simulring` needed slight modifications to parse an environment variable as a comma-separated list. `funlet-whisper` is an odd case; I couldn't quite parse out what it's supposed to do in full, and it's a port of an undocumented Twimlet.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
