### PR TITLE
Fixes/Polishes for COVID vaccine hesitancy chatbot template

### DIFF
--- a/covid-vaccine-faq-bot/.env
+++ b/covid-vaccine-faq-bot/.env
@@ -9,15 +9,17 @@ TWILIO_PHONE_NUMBER=
 # required: true
 GOOGLE_CLOUD_PROJECT_ID=
 
-# description:  A JSON key file for your Google service account 
+# description:  A JSON key file for your Google service account. If deploying via CodeExchange, paste the JSON contents of the service account key below.
 # format: file(json)
 # contentKey: SERVICE_ACCOUNT_KEY_CONTENT
 # link: https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys
 # required: true
 GOOGLE_APPLICATION_CREDENTIALS=/service-account-key.json
 
-#description: Language to be leveraged by chatbot, can be configured for multi-language chatbots
+#description: Language to be used by chatbot. Defaults to U.S. English. If changing, set to Dialogflow language tag (e.g. es).
 #format: text
+# required: false
+# link: https://cloud.google.com/dialogflow/es/docs/reference/language
 LANGUAGE_CODE=en-US
 
 # description: SID of the Vaccine Bot FAQ Studio Flow, will be set automatically by the app, no need to configure in advance

--- a/covid-vaccine-faq-bot/.env
+++ b/covid-vaccine-faq-bot/.env
@@ -4,7 +4,7 @@
 TWILIO_PHONE_NUMBER=
 
 # description: Your Google Cloud Project ID
-# link: https://cloud.google.com/dialogflow/cx/docs/quick/setup#project  
+# link: https://cloud.google.com/dialogflow/cx/docs/quick/setup#project
 # format: text
 # required: true
 GOOGLE_CLOUD_PROJECT_ID=
@@ -16,8 +16,8 @@ GOOGLE_CLOUD_PROJECT_ID=
 # required: true
 GOOGLE_APPLICATION_CREDENTIALS=/service-account-key.json
 
-#description: Language to be used by chatbot. Defaults to U.S. English. If changing, set to Dialogflow language tag (e.g. es).
-#format: text
+# description: Language to be used by chatbot. Defaults to U.S. English (en-US). Do not change if using pre-build chatbot agents. If changing, set to Dialogflow language tag (e.g. es).
+# format: text
 # required: false
 # link: https://cloud.google.com/dialogflow/es/docs/reference/language
 LANGUAGE_CODE=en-US

--- a/covid-vaccine-faq-bot/README.md
+++ b/covid-vaccine-faq-bot/README.md
@@ -40,8 +40,11 @@ In your `.env` file, set the following values:
 | `TWILIO PHONE NUMBER`            | Your Twilio phone number for sending and receiving SMS (find this [in the console here](https://www.twilio.com/console/phone-numbers/incoming))| Yes |
 | `DIALOGFLOW_ES_PROJECT_ID`       | Your Google Dialog Flow Project ID ([instructions here](https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects))                                                                                                              | Yes |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account key file (json) to authenticate into dialogflow API. Default is `/service-account-key.json`.                                                      | Yes  |
+| `LANGUAGE_CODE` | Language to be used by chatbot. Default is
+U.S. English, `en-US`. If changing, set to Dialogflow language
+tag found [here](https://cloud.google.com/dialogflow/es/docs/reference/language)                                                      | Yes  |
 
-There is a fourth environment variable, `FLOW_SID`, but that will be set automatically by the app. **Do not** set this value.
+There is a fifth environment variable, `FLOW_SID`, but that will be set automatically by the app. **Do not** set this value.
 | Variable | Description | Required |
 | :------------------------------- | :----------------------------------------------------------------------------------------------------------------------  | :-- |
 | `FLOW_SID`                       | SID of Studio Flow to orchestrate chatbot messaging. Will be set automatically by the app. Do not configure in advance.                                                                        | No  |

--- a/covid-vaccine-faq-bot/assets/client.js
+++ b/covid-vaccine-faq-bot/assets/client.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 /* eslint-disable no-undef */
+/* eslint-disable prefer-destructuring */
 let phoneNumber;
 let flowSid;
 

--- a/covid-vaccine-faq-bot/assets/client.js
+++ b/covid-vaccine-faq-bot/assets/client.js
@@ -13,7 +13,7 @@ const fullUrl = baseUrl.href.substr(0, baseUrl.href.length - 1);
 fetch(`${fullUrl}/return-config`)
   .then((response) => response.json())
   .then((json) => {
-    phoneNumber = json.phone_number;
+    phoneNumber = json.phoneNumber;
     // Grab the phone number being used and display it to help the user test their app
     const phoneNumberElements = $('.phone-number');
     phoneNumberElements.html(phoneNumber);

--- a/covid-vaccine-faq-bot/assets/service-account-key.private.json
+++ b/covid-vaccine-faq-bot/assets/service-account-key.private.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "<YOUR PROJECT ID HERE>",
+  "private_key_id": "<YOUR PRIVATE KEY ID HERE>",
+  "private_key": "<YOUR PRIVATE KEY BLOCK HERE>",
+  "client_email": "<YOUR SERVICE ACCOUNT EMAIL ADDRESS>",
+  "client_id": "<YOUR CLIENT ID>",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "<YOUR X509 CERT URL>"
+}

--- a/env-variables.manifest.json
+++ b/env-variables.manifest.json
@@ -1346,7 +1346,7 @@
         "key": "GOOGLE_APPLICATION_CREDENTIALS",
         "required": true,
         "format": "file(json)",
-        "description": "A JSON key file for your Google service account",
+        "description": "A JSON key file for your Google service account. If deploying via CodeExchange, paste the JSON contents of the service account key below.",
         "link": "https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys",
         "default": "/service-account-key.json",
         "configurable": true,
@@ -1354,10 +1354,10 @@
       },
       {
         "key": "LANGUAGE_CODE",
-        "required": true,
+        "required": false,
         "format": "text",
-        "description": "Language to be leveraged by chatbot, can be configured for multi-language chatbots",
-        "link": null,
+        "description": "Language to be used by chatbot. Defaults to U.S. English (en-US). Do not change if using pre-build chatbot agents. If changing, set to Dialogflow language tag (e.g. es).",
+        "link": "https://cloud.google.com/dialogflow/es/docs/reference/language",
         "default": "en-US",
         "configurable": true,
         "contentKey": null


### PR DESCRIPTION
- Fix GCP service account key file upload by adding a placeholder file in the `assets` directory for CodeExchange to populate with JSON
- Fix reference to Twilio phone number in the UI changed as a result of linting (`phone_number` --> `phoneNumber`)
- Make Dialogflow language code env variable optional
- Add some language to the `.env` and `README` files to help a user set environment variables correctly