### PR TITLE
feat(templates): add verify retry logic UI template

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This is the list of Functions available in this repo:
 - [Verify](verify) - Functions to send and check one-time passwords via SMS or Voice for phone verification
 - [Email Verification Magic Links](magic-links) - Send one-click email verification using Verify and SendGrid
 - [Verify Testing Dashboard](verify-dashboard) - Helpful dashboard for testing and debugging during your development with Twilio Verify.
+- [SMS verification retry best practices](verify-retry) - Best practices UI for resending SMS verification codes and voice channel fallback.
 
 ## Github Pages
 

--- a/templates.json
+++ b/templates.json
@@ -211,6 +211,11 @@
       "description": "Helpful dashboard for testing and debugging during your development with Twilio Verify."
     },
     {
+      "id": "verify-retry",
+      "name": "Verification with Retry Logic",
+      "description": "Best practices UI for resending SMS verification codes and voice channel fallback."
+    },
+    {
       "id": "verify-push-backend",
       "name": "Verify Push Backend",
       "description": "Issue access tokens and create push challenges from this helpful app and dashboard."

--- a/verify-retry/.env
+++ b/verify-retry/.env
@@ -1,0 +1,5 @@
+# description: SID of your Twilio Verify Service
+# format: sid
+# link: https://www.twilio.com/console/verify/services
+# required: true
+VERIFY_SERVICE_SID=

--- a/verify-retry/README.md
+++ b/verify-retry/README.md
@@ -1,0 +1,75 @@
+# Twilio Verify with Retry Logic
+
+This demo of the [Twilio Verify API](https://www.twilio.com/docs/verify/api) includes best practices for SMS verification retry logic with Voice fallback and landline detection.
+
+## Pre-requisites
+
+* A Verify Service. [Create one in the Twilio Console](https://www.twilio.com/console/verify/services)
+
+### Environment variables
+
+This project requires some environment variables to be set. To keep your tokens and secrets secure, make sure to not commit the `.env` file in git. When setting up the project with `twilio serverless:init ...` the Twilio CLI will create a `.gitignore` file that excludes `.env` from the version history.
+
+In your `.env` file, set the following values:
+
+| Variable             | Meaning                                                           | Required |
+| :------------------- | :---------------------------------------------------------------- | :------- |
+| `ACCOUNT_SID`        | Find in the [console](https://www.twilio.com/console)             | Yes      |
+| `AUTH_TOKEN`         | Find in the [console](https://www.twilio.com/console)             | Yes      |
+| `VERIFY_SERVICE_SID` | Create one [here](https://www.twilio.com/console/verify/services) | Yes      |
+
+### Function Parameters
+
+`start-verify.js` expects the following parameters:
+
+| Parameter      | Description                                 | Required |
+| :------------- | :------------------------------------------ | :------- |
+| `to`           | Either an email or phone number in [E.164 format](https://www.twilio.com/docs/glossary/what-e164) | Yes |
+| `channel`      | 'sms' or 'call'. Default is 'sms'           | No |
+
+`check-verify.js` expects the following parameters:
+
+| Parameter           | Description                | Required |
+| :------------------ | :------------------------- | :------- |
+| `to`                | Either an email or phone number in [E.164 format](https://www.twilio.com/docs/glossary/what-e164) | Yes |
+| `code`              | Collected from user input  | Yes      |
+
+## Create a new project with the template
+
+1. Install the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart#install-twilio-cli)
+2. Install the [serverless toolkit](https://www.twilio.com/docs/labs/serverless-toolkit/getting-started)
+
+```shell
+twilio plugins:install @twilio-labs/plugin-serverless
+```
+
+3. Initiate a new project
+
+```
+twilio serverless:init verify-retry-sample --template=verify-retry && cd verify-retry-sample
+```
+
+4. Add your environment variables to `.env`:
+
+Make sure variables are populated in your `.env` file. See [Environment variables](#environment-variables).
+
+5. Start the server :
+
+```
+twilio serverless:start
+```
+
+5. Open the web page at https://localhost:3000/index.html and enter your phone number to test
+
+ℹ️ Check the developer console and terminal for any errors, make sure you've set your environment variables.
+
+## Deploying
+
+Deploy your functions and assets with either of the following commands. Note: you must run these commands from inside your project folder. [More details in the docs.](https://www.twilio.com/docs/labs/serverless-toolkit)
+
+With the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart):
+
+```
+twilio serverless:deploy
+```
+

--- a/verify-retry/assets/index.html
+++ b/verify-retry/assets/index.html
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <title>SMS Verification with Voice fallback</title>
+
+    <link
+      rel="icon"
+      href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico"
+    />
+    <link
+      rel="stylesheet"
+      href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css"
+    />
+
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/16.0.11/css/intlTelInput.css"
+    />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/16.0.11/js/intlTelInput.min.js"></script>
+    <style>
+      main {
+        padding-top: 40px;
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        justify-content: flex-start;
+        width: 75%;
+        margin-left: auto;
+        margin-right: auto;
+      }
+
+      div.content {
+        max-width: 100%;
+      }
+
+      input[type="submit"],
+      input[type="tel"] {
+        font: inherit;
+        border: 1px solid rgb(136, 145, 170);
+        border-radius: 4px;
+      }
+
+      #retry,
+      #call {
+        display: block;
+        background-color: transparent;
+        border: none;
+        color: #509ee3;
+        text-decoration: underline;
+        padding: 0 0 10px 0;
+      }
+
+      #retry:hover,
+      #call:hover {
+        color: blue;
+        cursor: pointer;
+      }
+
+      #retry:disabled {
+        color: grey;
+        cursor: not-allowed;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page-top">
+      <header>
+        <div id="twilio-logo">
+          <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+            <svg
+              class="logo"
+              data-name="Layer 1"
+              xmlns="http://www.w3.org/2000/svg"
+              viewbox="0 0 60 60"
+            >
+              <title>Twilio Logo</title>
+              <path
+                class="cls-1"
+                d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"
+              />
+            </svg>
+          </a>
+        </div>
+        <nav>
+          <a href="/index.html" style="text-decoration: none; color: white"
+            ><span>Your Twilio Verify Application</span>
+            <aside>
+              <svg
+                class="icon"
+                role="img"
+                aria-hidden="true"
+                width="100%"
+                height="100%"
+                viewBox="0 0 20 20"
+                aria-labelledby="NewIcon-1577"
+              >
+                <path
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"
+                ></path>
+              </svg>
+              Live
+            </aside>
+          </a>
+        </nav>
+      </header>
+    </div>
+    <main>
+      <div class="content">
+        <section>
+          <p>
+            This demo of the
+            <a href="https://www.twilio.com/docs/verify/api">
+              Twilio Verify API
+            </a>
+            includes best practices for SMS verification retry logic with Voice
+            fallback and landline detection.
+          </p>
+          <hr />
+          <form id="login">
+            <div>
+              <label for="phone_number">Enter your phone number:</label>
+            </div>
+            <div>
+              <input type="tel" id="phone_number" class="form-control" />
+              <input type="submit" value="Get a verification code" />
+            </div>
+          </form>
+          <div>
+            <span id="status"></span>
+            <span id="reset"></span>
+          </div>
+          <form id="otp" style="display: none">
+            <div>
+              <label for="code">Enter the code sent to your device:</label>
+            </div>
+            <div>
+              <input type="text" id="code" placeholder="123456" required />
+              <input type="submit" value="Verify" />
+            </div>
+          </form>
+          <button id="retry" disabled="true" style="display: none"></button>
+          <button id="call" style="display: none">
+            📞 Having trouble receiving SMS, call me instead
+          </button>
+        </section>
+      </div>
+      <!-- EDIT_CODE_V2 -->
+    </main>
+    <footer>
+      <span>We can't wait to see what you build.</span>
+    </footer>
+  </body>
+  <script>
+    // Handle international prefixes, format phone input field
+    // Uses intl-tel-input library
+    const phoneInputField = document.querySelector("#phone_number");
+    const phoneInput = window.intlTelInput(phoneInputField, {
+      // https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+      preferredCountries: ["us", "gb", "de", "co", "jp", "sg"],
+      utilsScript:
+        "https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/16.0.11/js/utils.js",
+    });
+
+    function showError(error) {
+      console.error(error);
+      showStatus(error, (color = "#a94442"));
+    }
+
+    function showStatus(message, color = "gray") {
+      let status = document.getElementById("status");
+      status.style.color = color;
+      status.textContent = message;
+    }
+
+    function showReset(message) {
+      document.getElementById(
+        "reset"
+      ).innerHTML = `<a href="#" onclick="window.location.reload(false);">${message}</a>`;
+    }
+
+    function getRetryTimeout(attemptNumber) {
+      const retryTimeouts = {
+        1: 30,
+        2: 40,
+        3: 60,
+        4: 90,
+        5: 120,
+      };
+
+      const maxTimeout = 600;
+      const defaultTimeout =
+        maxTimeout - Object.values(retryTimeouts).reduce((a, b) => a + b);
+
+      return retryTimeouts[attemptNumber] || defaultTimeout;
+    }
+
+    function showOtpForm() {
+      document.getElementById("login").style.display = "none";
+      document.getElementById("otp").style.display = "block";
+    }
+
+    function showCallFallback(attempts) {
+      let minAttemptForVoice = 3;
+      if (attempts < minAttemptForVoice) return;
+
+      document.getElementById("call").style.display = "block";
+    }
+
+    let timer;
+    let timeRemaining;
+    let retryButton = document.getElementById("retry");
+
+    function startCountdown(attempts) {
+      clearInterval(timer);
+      retryButton.setAttribute("disabled", true);
+      retryButton.style.display = "block";
+
+      console.log(`Attempt number: ${attempts}`);
+      timeRemaining = getRetryTimeout(attempts);
+      timer = setInterval(() => countdown(attempts), 1000);
+    }
+
+    function countdown(attempts) {
+      if (timeRemaining == 0) {
+        clearInterval(timer);
+        retryButton.removeAttribute("disabled");
+        retryButton.innerHTML = "🔁 Resend code";
+      } else {
+        if (timeRemaining == 15) {
+          showCallFallback(attempts);
+        }
+        retryButton.innerHTML = `🔁 Resend code in <strong>${timeRemaining} seconds</strong>`;
+        timeRemaining--;
+      }
+    }
+
+    var to;
+
+    function sendVerificationToken(event, channel = "sms") {
+      event.preventDefault();
+      let statusMessage =
+        channel == "call" ? "☎️ calling..." : "Sending verification code...";
+      showStatus(statusMessage);
+
+      to = phoneInput.getNumber();
+
+      const data = new URLSearchParams();
+      data.append("channel", channel);
+      data.append("to", to);
+
+      fetch("./start-verify", {
+        method: "POST",
+        body: data,
+      })
+        .then((response) => {
+          if (response.status == 429) {
+            clearStatus();
+            showOtpForm();
+            showError(
+              `You have attempted to verify the phone number ${to} too many times. If you received a code, enter it below. Otherwise, please wait 10 minutes and `
+            );
+            showReset("try again.");
+          } else if (response.status >= 400) {
+            clearStatus();
+            document.getElementById("otp").style.display = "none";
+            document.getElementById("login").style.display = "flex";
+
+            return response.json().then(({ message }) => {
+              showError(message);
+            });
+          } else {
+            showOtpForm();
+            return response.json().then((json) => {
+              if (json.success) {
+                showStatus(json.message + `.`);
+                startCountdown(json.attempts);
+              } else {
+                showError(json.message);
+              }
+              showReset("Edit phone number.");
+            });
+          }
+        })
+        .catch(() => {
+          showError(`Something went wrong while sending code to ${to}.`);
+          showReset("Edit phone number.");
+        });
+    }
+
+    function clearStatus() {
+      clearInterval(timer);
+      document.getElementById("status").textContent = "";
+      document.getElementById("reset").innerHTML = "";
+      document.getElementById("retry").style.display = "none";
+      document.getElementById("call").style.display = "none";
+    }
+
+    function retrySend(event) {
+      clearStatus();
+      sendVerificationToken(event);
+    }
+
+    function sendVoiceToken(event) {
+      clearStatus();
+      sendVerificationToken(event, (channel = "call"));
+    }
+
+    function validateToken(event) {
+      event.preventDefault();
+      clearStatus();
+      showStatus("Checking code...");
+
+      const data = new URLSearchParams();
+      data.append("to", to);
+      data.append("code", document.getElementById("code").value);
+
+      var tags = document.querySelectorAll("input[name=tags]:checked");
+      tags.forEach((tag) => data.append("tags", tag.value));
+
+      fetch("./check-verify", {
+        method: "POST",
+        body: data,
+      })
+        .then((response) => {
+          return response.json();
+        })
+        .then((json) => {
+          if (json.success) {
+            clearStatus();
+            document.getElementById("otp").style.display = "none";
+            showStatus(json.message, (color = "#3c763d"));
+          } else {
+            showError(`${json.message} Check the code sent to ${to}.`);
+          }
+          showReset(
+            "Use a different phone number or start a new verification."
+          );
+          document.getElementById("code").value = "";
+        })
+        .catch((error) => {
+          showError(error);
+        });
+    }
+
+    document
+      .getElementById("login")
+      .addEventListener("submit", sendVerificationToken);
+    document.getElementById("retry").addEventListener("click", retrySend);
+    document.getElementById("call").addEventListener("click", sendVoiceToken);
+    document.getElementById("otp").addEventListener("submit", validateToken);
+  </script>
+</html>

--- a/verify-retry/assets/utils.private.js
+++ b/verify-retry/assets/utils.private.js
@@ -1,0 +1,22 @@
+class VerificationException extends Error {
+  constructor(status, message) {
+    super(`Error ${status}: ${message}`);
+
+    this.status = status;
+    this.message = message;
+  }
+}
+
+function detectMissingParams(paramNames, event) {
+  return paramNames.reduce((acc, param) => {
+    if (typeof event[param] === 'undefined') {
+      acc.push(param);
+    }
+    return acc;
+  }, []);
+}
+
+module.exports = {
+  VerificationException,
+  detectMissingParams,
+};

--- a/verify-retry/functions/check-verify.js
+++ b/verify-retry/functions/check-verify.js
@@ -69,7 +69,6 @@ exports.handler = async function (context, event, callback) {
     });
     return callback(null, response);
   } catch (error) {
-    console.error(error);
     response.setStatusCode(error.status);
     response.setBody({
       success: false,

--- a/verify-retry/functions/check-verify.js
+++ b/verify-retry/functions/check-verify.js
@@ -1,0 +1,75 @@
+/**
+ *  Check Verification
+ *
+ *  This Function shows you how to check a verification token for Twilio Verify.
+ *
+ *  Pre-requisites
+ *  - Create a Verify Service (https://www.twilio.com/console/verify/services)
+ *  - Add VERIFY_SERVICE_SID from above to your Environment Variables (https://www.twilio.com/console/functions/configure)
+ *  - Enable ACCOUNT_SID and AUTH_TOKEN in your functions configuration (https://www.twilio.com/console/functions/configure)
+ *
+ *
+ *  Returns JSON:
+ *  {
+ *    "success": boolean,
+ *    "message": string
+ *  }
+ */
+
+// eslint-disable-next-line consistent-return
+exports.handler = function (context, event, callback) {
+  const response = new Twilio.Response();
+  response.appendHeader('Content-Type', 'application/json');
+
+  /*
+   * uncomment to support CORS
+   * response.appendHeader('Access-Control-Allow-Origin', '*');
+   * response.appendHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+   * response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
+   */
+
+  if (typeof event.to === 'undefined' || typeof event.code === 'undefined') {
+    response.setBody({
+      success: false,
+      message: 'Missing parameter.',
+    });
+    response.setStatusCode(400);
+    return callback(null, response);
+  }
+
+  const client = context.getTwilioClient();
+  const service = context.VERIFY_SERVICE_SID;
+  const { to, code } = event;
+
+  client.verify
+    .services(service)
+    .verificationChecks.create({
+      to,
+      code,
+    })
+    .then((check) => {
+      if (check.status === 'approved') {
+        response.setStatusCode(200);
+        response.setBody({
+          success: true,
+          message: 'Verification success.',
+        });
+        return callback(null, response);
+      }
+      response.setStatusCode(401);
+      response.setBody({
+        success: false,
+        message: 'Incorrect token.',
+      });
+      return callback(null, response);
+    })
+    .catch((error) => {
+      console.log(error);
+      response.setStatusCode(error.status);
+      response.setBody({
+        success: false,
+        message: error.message,
+      });
+      return callback(null, response);
+    });
+};

--- a/verify-retry/functions/start-verify.js
+++ b/verify-retry/functions/start-verify.js
@@ -1,0 +1,98 @@
+/**
+ *  Start Verification
+ *
+ *  This Function shows you how to send a verification token for Twilio Verify.
+ *
+ *  Pre-requisites
+ *  - Create a Verify Service (https://www.twilio.com/console/verify/services)
+ *  - Add VERIFY_SERVICE_SID from above to your Environment Variables (https://www.twilio.com/console/functions/configure)
+ *  - Enable ACCOUNT_SID and AUTH_TOKEN in your functions configuration (https://www.twilio.com/console/functions/configure)
+ *
+ *
+ *  Returns JSON
+ *  {
+ *    "success":  boolean,
+ *    "attempts": integer, // not present if success is false
+ *    "message":  string
+ *  }
+ */
+
+// eslint-disable-next-line consistent-return
+exports.handler = function (context, event, callback) {
+  const response = new Twilio.Response();
+  response.appendHeader('Content-Type', 'application/json');
+
+  /*
+   * uncomment to support CORS
+   * response.appendHeader('Access-Control-Allow-Origin', '*');
+   * response.appendHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+   * response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
+   */
+
+  if (typeof event.to === 'undefined') {
+    response.setBody({
+      success: false,
+      message: 'Missing parameter; please provide a phone number.',
+    });
+    response.setStatusCode(400);
+    return callback(null, response);
+  }
+
+  const client = context.getTwilioClient();
+  const service = context.VERIFY_SERVICE_SID;
+  const { to } = event;
+
+  const lookupResponse = client.lookups.v1
+    .phoneNumbers(to)
+    .fetch({ type: ['carrier'] })
+    .then((pn) => pn.carrier.type);
+
+  lookupResponse
+    .then((lineType) => {
+      let channel;
+      let message;
+
+      if (lineType === 'landline') {
+        channel = 'call';
+        message = `Landline detected. Sent ${channel} verification to: ${to}`;
+      } else {
+        channel = typeof event.channel === 'undefined' ? 'sms' : event.channel;
+        message = `Sent ${channel} verification to: ${to}`;
+      }
+
+      client.verify
+        .services(service)
+        .verifications.create({
+          to,
+          channel,
+        })
+        .then((verification) => {
+          console.log(`Sent verification ${verification.sid}`);
+          response.setStatusCode(200);
+          response.setBody({
+            success: true,
+            attempts: verification.sendCodeAttempts.length,
+            message,
+          });
+          return callback(null, response);
+        })
+        .catch((error) => {
+          console.log(error);
+          response.setStatusCode(error.status);
+          response.setBody({
+            success: false,
+            message: error.message,
+          });
+          return callback(null, response);
+        });
+    })
+    .catch((error) => {
+      console.log(error);
+      response.setStatusCode(error.status);
+      response.setBody({
+        success: false,
+        message: `Invalid phone number: '${to}'`,
+      });
+      return callback(null, response);
+    });
+};

--- a/verify-retry/functions/start-verify.js
+++ b/verify-retry/functions/start-verify.js
@@ -63,15 +63,12 @@ exports.handler = async function (context, event, callback) {
 
     const lineType = await getLineType(client, to);
 
-    let channel;
-    let message;
+    let channel = typeof event.channel === 'undefined' ? 'sms' : event.channel;
+    let message = `Sent ${channel} verification to: ${to}`;
 
     if (lineType === 'landline') {
       channel = 'call';
       message = `Landline detected. Sent ${channel} verification to: ${to}`;
-    } else {
-      channel = typeof event.channel === 'undefined' ? 'sms' : event.channel;
-      message = `Sent ${channel} verification to: ${to}`;
     }
 
     const verification = await client.verify
@@ -89,7 +86,6 @@ exports.handler = async function (context, event, callback) {
     });
     return callback(null, response);
   } catch (error) {
-    console.log(error);
     response.setStatusCode(error.status);
     response.setBody({
       success: false,

--- a/verify-retry/package.json
+++ b/verify-retry/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "twilio": "^3.61.0"
+  }
+}

--- a/verify-retry/tests/check-verify.test.js
+++ b/verify-retry/tests/check-verify.test.js
@@ -1,0 +1,133 @@
+const checkVerifyFunction = require('../functions/check-verify').handler;
+const helpers = require('../../test/test-helper');
+
+const mockService = {
+  verificationChecks: {
+    create: jest.fn(() =>
+      Promise.resolve({
+        status: 'approved',
+      })
+    ),
+  },
+};
+
+const mockClient = {
+  verify: {
+    services: jest.fn(() => mockService),
+  },
+};
+
+const testContext = {
+  VERIFY_SERVICE_SID: 'default',
+  getTwilioClient: () => mockClient,
+};
+
+describe('verify-retry/check-verification', () => {
+  beforeAll(() => {
+    helpers.setup({});
+  });
+  afterAll(() => {
+    helpers.teardown();
+  });
+
+  test('returns an error response when required to parameter is missing', (done) => {
+    const callback = (_err, result) => {
+      expect(result).toBeDefined();
+      expect(result._body.success).toEqual(false);
+      expect(mockClient.verify.services).not.toHaveBeenCalledWith(
+        testContext.VERIFY_SERVICE_SID
+      );
+      done();
+    };
+    const event = {
+      code: '123456',
+    };
+    checkVerifyFunction(testContext, event, callback);
+  });
+
+  test('returns an error response when required code parameter is missing', (done) => {
+    const callback = (_err, result) => {
+      expect(result).toBeDefined();
+      expect(result._body.success).toEqual(false);
+      expect(mockClient.verify.services).not.toHaveBeenCalledWith(
+        testContext.VERIFY_SERVICE_SID
+      );
+      done();
+    };
+    const event = {
+      to: '+17341234567',
+    };
+    checkVerifyFunction(testContext, event, callback);
+  });
+
+  test('returns an error response when required parameters are missing', (done) => {
+    const callback = (_err, result) => {
+      expect(result).toBeDefined();
+      expect(result._body.success).toEqual(false);
+      expect(mockClient.verify.services).not.toHaveBeenCalledWith(
+        testContext.VERIFY_SERVICE_SID
+      );
+      done();
+    };
+    const event = {};
+    checkVerifyFunction(testContext, event, callback);
+  });
+
+  test('returns success with valid request', (done) => {
+    const callback = (_err, result) => {
+      expect(result).toBeDefined();
+      expect(result._body.success).toEqual(true);
+      expect(mockClient.verify.services).toHaveBeenCalledWith(
+        testContext.VERIFY_SERVICE_SID
+      );
+      const expectedParameters = {
+        code: '123456',
+        to: '+17341234567',
+      };
+      expect(mockService.verificationChecks.create).toHaveBeenCalledWith(
+        expectedParameters
+      );
+      done();
+    };
+    const event = {
+      to: '+17341234567',
+      code: '123456',
+    };
+    checkVerifyFunction(testContext, event, callback);
+  });
+
+  test('returns error with invalid tokent', (done) => {
+    const mockInvalidTokenService = {
+      verificationChecks: {
+        create: jest.fn(() =>
+          Promise.resolve({
+            status: 'pending',
+          })
+        ),
+      },
+    };
+
+    const mockInvalidTokenClient = {
+      verify: {
+        services: jest.fn(() => mockInvalidTokenService),
+      },
+    };
+
+    const invalidTokenContext = {
+      getTwilioClient: () => mockInvalidTokenClient,
+    };
+
+    const callback = (_err, result) => {
+      expect(result).toBeDefined();
+      expect(result._body.success).toEqual(false);
+      expect(result._body.message).toEqual('Incorrect token.');
+      done();
+    };
+
+    const event = {
+      to: '+17341234567',
+      code: '1234',
+    };
+    checkVerifyFunction(invalidTokenContext, event, callback);
+  });
+});

--- a/verify-retry/tests/start-verify.test.js
+++ b/verify-retry/tests/start-verify.test.js
@@ -150,7 +150,7 @@ describe('verify-retry/start-verify', () => {
 
   test('throws an error if the lookup returns an invalid number', (done) => {
     const mockFetchError = {
-      fetch: jest.fn().mockImplementation(async () => {
+      fetch: jest.fn().mockImplementation(() => {
         throw new VerificationException(404, 'Phone Number Not Found!');
       }),
     };

--- a/verify-retry/tests/start-verify.test.js
+++ b/verify-retry/tests/start-verify.test.js
@@ -26,7 +26,6 @@ const mockClient = {
 
 const testContext = {
   VERIFY_SERVICE_SID: 'default',
-  BROADCAST_ADMIN_NUMBER: '+12223334444',
   getTwilioClient: () => mockClient,
 };
 
@@ -145,8 +144,7 @@ describe('verify-retry/start-verify', () => {
     };
 
     const callback = (err, result) => {
-      expect(err).toBeDefined();
-      expect(result).toBeDefined();
+      expect(err).toBeNull();
       expect(result._body.success).toEqual(false);
       expect(result._body.message).toEqual(`Invalid phone number: '123'`);
       done();

--- a/verify-retry/tests/start-verify.test.js
+++ b/verify-retry/tests/start-verify.test.js
@@ -1,0 +1,157 @@
+const startVerifyFunction = require('../functions/start-verify').handler;
+const helpers = require('../../test/test-helper');
+
+const mockService = {
+  verifications: {
+    create: jest
+      .fn()
+      .mockResolvedValue({ sid: 'my-new-sid', sendCodeAttempts: [1, 2, 3] }),
+  },
+};
+
+const mockLookups = {
+  fetch: jest.fn().mockResolvedValue({ carrier: { type: 'mobile' } }),
+};
+
+const mockClient = {
+  verify: {
+    services: jest.fn(() => mockService),
+  },
+  lookups: {
+    v1: {
+      phoneNumbers: jest.fn(() => mockLookups),
+    },
+  },
+};
+
+const testContext = {
+  VERIFY_SERVICE_SID: 'default',
+  BROADCAST_ADMIN_NUMBER: '+12223334444',
+  getTwilioClient: () => mockClient,
+};
+
+describe('verify-retry/start-verify', () => {
+  beforeAll(() => {
+    helpers.setup({});
+  });
+  afterAll(() => {
+    helpers.teardown();
+  });
+
+  test('returns an error if no phone number is provided', (done) => {
+    const callback = (_err, result) => {
+      expect(result).toBeDefined();
+      expect(result._body.success).toEqual(false);
+      expect(result._body.message).toEqual(
+        'Missing parameter; please provide a phone number.'
+      );
+      expect(mockClient.verify.services).not.toHaveBeenCalledWith(
+        testContext.VERIFY_SERVICE_SID
+      );
+      done();
+    };
+    const event = {};
+    startVerifyFunction(testContext, event, callback);
+  });
+
+  test('looks up a phone number before sending verification code', (done) => {
+    const callback = (err, result) => {
+      expect(err).toBeNull();
+      expect(result).toBeDefined();
+      expect(mockClient.lookups.v1.phoneNumbers).toHaveBeenCalledWith(
+        '+17341234567'
+      );
+      done();
+    };
+    const event = { to: '+17341234567' };
+    startVerifyFunction(testContext, event, callback);
+  });
+
+  test('uses call parameter if it detects a landline', (done) => {
+    const mockLandlineLookup = {
+      fetch: jest.fn().mockResolvedValue({ carrier: { type: 'landline' } }),
+    };
+
+    const mockLandlineClient = {
+      verify: {
+        services: jest.fn(() => mockService),
+      },
+      lookups: {
+        v1: {
+          phoneNumbers: jest.fn(() => mockLandlineLookup),
+        },
+      },
+    };
+
+    const landlineContext = {
+      VERIFY_SERVICE_SID: 'landline-sid',
+      getTwilioClient: () => mockLandlineClient,
+    };
+
+    const callback = (err, result) => {
+      expect(err).toBeNull();
+      expect(result).toBeDefined();
+      expect(result._body.success).toEqual(true);
+      expect(result._body.attempts).toEqual(3);
+      expect(mockLandlineClient.verify.services).toHaveBeenCalledWith(
+        landlineContext.VERIFY_SERVICE_SID
+      );
+      const expectedContext = { channel: 'call', to: '+17341234567' };
+      expect(mockService.verifications.create).toHaveBeenCalledWith(
+        expectedContext
+      );
+      done();
+    };
+    const event = { to: '+17341234567' };
+    startVerifyFunction(landlineContext, event, callback);
+  });
+
+  test('returns success and attempts with valid request', (done) => {
+    const callback = (err, result) => {
+      expect(err).toBeNull();
+      expect(result).toBeDefined();
+      expect(result._body.success).toEqual(true);
+      expect(result._body.attempts).toEqual(3);
+      expect(mockClient.verify.services).toHaveBeenCalledWith(
+        testContext.VERIFY_SERVICE_SID
+      );
+      const expectedContext = { channel: 'sms', to: '+17341234567' };
+      expect(mockService.verifications.create).toHaveBeenCalledWith(
+        expectedContext
+      );
+      done();
+    };
+    const event = { to: '+17341234567' };
+    startVerifyFunction(testContext, event, callback);
+  });
+
+  test('throws an error if the lookup returns an invalid number', (done) => {
+    const mockFetchError = {
+      fetch: jest.fn().mockImplementation(() => {
+        throw new Error('error!');
+      }),
+    };
+
+    const mockLookupError = {
+      lookups: {
+        v1: {
+          phoneNumbers: jest.fn(() => mockFetchError),
+        },
+      },
+    };
+
+    const errorContext = {
+      getTwilioClient: () => mockLookupError,
+    };
+
+    const callback = (err, result) => {
+      expect(err).toBeDefined();
+      expect(result).toBeDefined();
+      expect(result._body.success).toEqual(false);
+      expect(result._body.message).toEqual(`Invalid phone number: '123'`);
+      done();
+    };
+    const event = { to: '123' };
+    startVerifyFunction(errorContext, event, callback);
+  });
+});


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

This project builds on the OTP verification but focuses on the UI/UX best practices around retry logic and voice fallback. There are more details in this blog post: https://www.twilio.com/blog/best-practices-retry-logic-sms-2fa

This is my first time using the async/await pattern for a function template which cleaned up the code and made testing easier, but let me know if anything looks off.

Live demo: https://verify-retry-6659-dev.twil.io/index.html

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
