### PR TITLE
Add versioning and changelogs to QD apps

### DIFF
--- a/_helpers/meta-template/CHANGELOG.md
+++ b/_helpers/meta-template/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/_helpers/meta-template/package.json
+++ b/_helpers/meta-template/package.json
@@ -1,4 +1,6 @@
 {
   "name": "{{name}}",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/airtable/changelog.md
+++ b/airtable/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/airtable/package.json
+++ b/airtable/package.json
@@ -1,5 +1,7 @@
 {
   "name": "airtable-sms-save",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "airtable": "^0.11.0"
   }

--- a/blank/changelog.md
+++ b/blank/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/blank/package.json
+++ b/blank/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/blocklist-call/changelog.md
+++ b/blocklist-call/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/blocklist-call/package.json
+++ b/blocklist-call/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/chat-token/changelog.md
+++ b/chat-token/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/chat-token/package.json
+++ b/chat-token/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/conference-caller-gated/changelog.md
+++ b/conference-caller-gated/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/conference-caller-gated/package.json
+++ b/conference-caller-gated/package.json
@@ -1,4 +1,6 @@
 {
   "name": "conference-caller-gated",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/conference-pin/changelog.md
+++ b/conference-pin/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/conference-pin/package.json
+++ b/conference-pin/package.json
@@ -1,4 +1,6 @@
 {
   "name": "conference-pin",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/conference-verify/changelog.md
+++ b/conference-verify/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/conference-verify/package.json
+++ b/conference-verify/package.json
@@ -1,4 +1,6 @@
 {
   "name": "conference-verify",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/conference/changelog.md
+++ b/conference/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/conference/package.json
+++ b/conference/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/conversations/changelog.md
+++ b/conversations/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/conversations/package.json
+++ b/conversations/package.json
@@ -1,5 +1,7 @@
 {
   "name": "conversations",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "twilio": "^3.61.0"
   }

--- a/covid-vaccine-faq-bot/changelog.md
+++ b/covid-vaccine-faq-bot/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/covid-vaccine-faq-bot/package.json
+++ b/covid-vaccine-faq-bot/package.json
@@ -1,5 +1,7 @@
 {
   "name": "covid-vaccine-faq-bot",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "@google-cloud/dialogflow": "^4.1.0",
     "crypto": "^1.0.1",

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -92,6 +92,10 @@ If your app has a front-end component to it, you can override the existing `inde
 
 In case your app does not contain a front-end component you should update the `index.html` file to reflect what steps a customer should perform to make the app work, once your template has been deployed.
 
+### Versioning and `CHANGELOG.md`
+
+Every Quick Deploy app has a version field in its `package.json` that follows [semantic versioning](https://semver.org/), and a `CHANGELOG.md` file that uses the [keep a changelog](https://keepachangelog.com/en/1.0.0/) format. Initially your app will be at version 1.0.0. If you are updating an app that has already been published to Code Exchange, please increment its version number according to the semantic versioning specification, and update its changelog with the changes you have made to the app since its last version. Versioning your app before it gets deployed by users will help isolate issues in a particular version of the app, and will also enable your app to take advantage of a future update mechanism for deployed apps.
+
 ## Testing
 
 ### Testing the functionality of your new template locally

--- a/forward-call/changelog.md
+++ b/forward-call/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/forward-call/package.json
+++ b/forward-call/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/forward-message-mailgun/changelog.md
+++ b/forward-message-mailgun/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/forward-message-mailgun/package.json
+++ b/forward-message-mailgun/package.json
@@ -1,5 +1,7 @@
 {
   "name": "forward-message-mailgun",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "mailgun.js": "^3.3.0"
   }

--- a/forward-message-multiple/changelog.md
+++ b/forward-message-multiple/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/forward-message-multiple/package.json
+++ b/forward-message-multiple/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/forward-message-sendgrid/changelog.md
+++ b/forward-message-sendgrid/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/forward-message-sendgrid/package.json
+++ b/forward-message-sendgrid/package.json
@@ -1,4 +1,6 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "got": "^6.7.1"
   }

--- a/forward-message-sparkpost/changelog.md
+++ b/forward-message-sparkpost/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/forward-message-sparkpost/package.json
+++ b/forward-message-sparkpost/package.json
@@ -1,4 +1,6 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "got": "^6.7.1"
   }

--- a/forward-message/changelog.md
+++ b/forward-message/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/forward-message/package.json
+++ b/forward-message/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/funlet-call-me/changelog.md
+++ b/funlet-call-me/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/funlet-call-me/package.json
+++ b/funlet-call-me/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/funlet-echo/changelog.md
+++ b/funlet-echo/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/funlet-echo/package.json
+++ b/funlet-echo/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/funlet-find-me/changelog.md
+++ b/funlet-find-me/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/funlet-find-me/package.json
+++ b/funlet-find-me/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/funlet-forward/changelog.md
+++ b/funlet-forward/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/funlet-forward/package.json
+++ b/funlet-forward/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/funlet-simple-menu/changelog.md
+++ b/funlet-simple-menu/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/funlet-simple-menu/package.json
+++ b/funlet-simple-menu/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/funlet-simple-message/changelog.md
+++ b/funlet-simple-message/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/funlet-simple-message/package.json
+++ b/funlet-simple-message/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/funlet-simulring/changelog.md
+++ b/funlet-simulring/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/funlet-simulring/package.json
+++ b/funlet-simulring/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/funlet-whisper/changelog.md
+++ b/funlet-whisper/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/funlet-whisper/package.json
+++ b/funlet-whisper/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/google-sheets/changelog.md
+++ b/google-sheets/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/google-sheets/package.json
+++ b/google-sheets/package.json
@@ -1,5 +1,7 @@
 {
   "name": "google-sheets",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "googleapis": "^65.0.0"
   }

--- a/hello-messaging/changelog.md
+++ b/hello-messaging/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/hello-messaging/package.json
+++ b/hello-messaging/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/hello-voice/changelog.md
+++ b/hello-voice/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/hello-voice/package.json
+++ b/hello-voice/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/hello-world/changelog.md
+++ b/hello-world/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/http-redirect/changelog.md
+++ b/http-redirect/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/http-redirect/package.json
+++ b/http-redirect/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/hunt/changelog.md
+++ b/hunt/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/hunt/package.json
+++ b/hunt/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/international-telephone-input/changelog.md
+++ b/international-telephone-input/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/international-telephone-input/package.json
+++ b/international-telephone-input/package.json
@@ -1,4 +1,6 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "twilio": "^3.61.0"
   }

--- a/json-webhook/changelog.md
+++ b/json-webhook/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/json-webhook/package.json
+++ b/json-webhook/package.json
@@ -1,5 +1,7 @@
 {
   "name": "json-webhook",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "node-fetch": "^2.6.1"
   }

--- a/magic-links/changelog.md
+++ b/magic-links/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/magic-links/package.json
+++ b/magic-links/package.json
@@ -1,4 +1,6 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "twilio": "^3.61.0"
   }

--- a/masked-number/changelog.md
+++ b/masked-number/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/masked-number/package.json
+++ b/masked-number/package.json
@@ -1,4 +1,6 @@
 {
   "name": "masked-number",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/never-gonna-give-you-up/changelog.md
+++ b/never-gonna-give-you-up/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/never-gonna-give-you-up/package.json
+++ b/never-gonna-give-you-up/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/patient-appointment-management/changelog.md
+++ b/patient-appointment-management/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/patient-appointment-management/package.json
+++ b/patient-appointment-management/package.json
@@ -1,5 +1,7 @@
 {
   "name": "patient-appointment-management",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "twilio": "^3.61.0",
     "aws-sdk": "^2.925.0",

--- a/segment-event-notification/changelog.md
+++ b/segment-event-notification/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/segment-event-notification/package.json
+++ b/segment-event-notification/package.json
@@ -1,4 +1,6 @@
 {
   "name": "segment-event-notification",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/sip-quickstart/changelog.md
+++ b/sip-quickstart/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/sip-quickstart/package.json
+++ b/sip-quickstart/package.json
@@ -1,5 +1,7 @@
 {
   "name": "sip-quickstart",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "common-tags": "^1.8.0",
     "twilio": "^3.61.0"

--- a/sms-broadcast/changelog.md
+++ b/sms-broadcast/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/sms-broadcast/package.json
+++ b/sms-broadcast/package.json
@@ -1,4 +1,6 @@
 {
   "name": "sms-broadcast",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/sms-notifications/changelog.md
+++ b/sms-notifications/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/sms-notifications/package.json
+++ b/sms-notifications/package.json
@@ -1,4 +1,6 @@
 {
   "name": "sms-notifications",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/stripe-payment-link-sms/changelog.md
+++ b/stripe-payment-link-sms/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/stripe-payment-link-sms/package.json
+++ b/stripe-payment-link-sms/package.json
@@ -1,5 +1,7 @@
 {
   "name": "stripe-payment-link-sms",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "stripe": "^8.20.0"
   }

--- a/stripe-sms-receipt/changelog.md
+++ b/stripe-sms-receipt/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/stripe-sms-receipt/package.json
+++ b/stripe-sms-receipt/package.json
@@ -1,5 +1,7 @@
 {
   "name": "stripe-sms-receipt",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "stripe": "^8.20.0"
   }

--- a/sync-token/changelog.md
+++ b/sync-token/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/sync-token/package.json
+++ b/sync-token/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/temp-storage/changelog.md
+++ b/temp-storage/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/temp-storage/package.json
+++ b/temp-storage/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/vaccine-standby/changelog.md
+++ b/vaccine-standby/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/vaccine-standby/package.json
+++ b/vaccine-standby/package.json
@@ -1,5 +1,7 @@
 {
   "name": "vaccine-standby",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "twilio": "^3.61.0"
   }

--- a/verified-broadcast/changelog.md
+++ b/verified-broadcast/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/verified-broadcast/package.json
+++ b/verified-broadcast/package.json
@@ -1,4 +1,6 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "twilio": "^3.61.0"
   }

--- a/verify-dashboard/changelog.md
+++ b/verify-dashboard/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/verify-dashboard/package.json
+++ b/verify-dashboard/package.json
@@ -1,4 +1,6 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "twilio": "^3.61.0"
   }

--- a/verify-push-backend/changelog.md
+++ b/verify-push-backend/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/verify-push-backend/package.json
+++ b/verify-push-backend/package.json
@@ -1,4 +1,6 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "twilio": "^3.61.0"
   }

--- a/verify-retry/changelog.md
+++ b/verify-retry/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/verify-retry/package.json
+++ b/verify-retry/package.json
@@ -1,4 +1,6 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "twilio": "^3.61.0"
   }

--- a/verify/changelog.md
+++ b/verify/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/verify/package.json
+++ b/verify/package.json
@@ -1,4 +1,6 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "twilio": "^3.61.0"
   }

--- a/video-token/changelog.md
+++ b/video-token/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/video-token/package.json
+++ b/video-token/package.json
@@ -1,3 +1,5 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/video/changelog.md
+++ b/video/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/video/package.json
+++ b/video/package.json
@@ -1,4 +1,6 @@
 {
   "name": "video",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/voice-client-javascript/changelog.md
+++ b/voice-client-javascript/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/voice-client-javascript/package.json
+++ b/voice-client-javascript/package.json
@@ -1,4 +1,6 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "common-tags": "^1.8.0",
     "twilio": "^3.61.0"

--- a/voice-ivr/changelog.md
+++ b/voice-ivr/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/voice-ivr/package.json
+++ b/voice-ivr/package.json
@@ -1,4 +1,6 @@
 {
   "name": "voice-ivr",
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {}
 }

--- a/voicemail/changelog.md
+++ b/voicemail/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/voicemail/package.json
+++ b/voicemail/package.json
@@ -1,4 +1,6 @@
 {
+  "version": "1.0.0",
+  "private": true,
   "dependencies": {
     "moment": "^2.24.0"
   }


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

Sets the versions of all Quick Deploy apps to `1.0.0`, and adds a `CHANGELOG.md` based around the [keep a changelog](https://keepachangelog.com/en/1.0.0/) format to `meta-template`. This is the groundwork to enable @dkundel's ideas around an update mechanism for deployed Quick Deploy apps.

Some things to consider:
- Currently, changelogs are handled manually. I couldn't find any tooling that would non-clumsily support multiple changelogs in a single Git repo. If anyone's aware of a good option here, please let me know.
- Only `meta-template` has a changelog so far. I plan to copy its skeleton changelog to each app in the repo, if the keep a changelog format is considered acceptable.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
