### PR TITLE
Enforce test coverage minimums

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,17 @@
   "jest": {
     "testEnvironment": "node",
     "collectCoverage": true,
+    "coverageThreshold": {
+      "./**/functions/**/*.js": {
+        "statements": 60,
+        "branches": 60
+      }
+    },
     "coveragePathIgnorePatterns": [
       "/node_modules/",
-      "/test/"
+      "/test/",
+      "/patient-appointment-management/",
+      "/video/"
     ],
     "testPathIgnorePatterns": [
       "/_helpers/",


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

Sets our Jest test coverage minimum to 60% for statements and branches, for any Javascript file under an app's `functions` directory (or any Javascript files in subdirectories under that). Two apps are filtered out of test coverage because they do not hit these minimums: `video` and `patient-appointment-management`. This was done in `coveragePathIgnorePatterns` instead of adding a glob to `coverageThreshold` due to a Jest bug that causes unexpected behavior when more than one glob matches a pattern. This check should also automatically catch files with no tests which do not appear in the default coverage report.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
