### PR TITLE
fix(verified-broadcast): adjust usage steps and setup logic

### DIFF
--- a/verified-broadcast/assets/index.html
+++ b/verified-broadcast/assets/index.html
@@ -73,34 +73,10 @@
           <p>Follow these steps to try out your new app:</p>
           <ol class="steps">
             <li>
-              Buy a
-              <a href="https://www.twilio.com/console/phone-numbers"
-                >Twilio Phone number</a
-              >
-              (or use an existing phone number).
+              Head over to the <a href="/subscribe.html" target="_blank">subscribe page</a> and enter your phone number.
             </li>
             <li>
-              Create a
-              <a href="https://www.twilio.com/console/sms/services"
-                >Messaging Service in the Twilio Console and select "not listed
-                here" as the use case.</a
-              >
-            </li>
-            <li>
-              Add your Twilio Phone number as a sender to your messaging
-              service.
-            </li>
-            <li>
-              Select your
-              <a href="https://www.twilio.com/console/notify/services"
-                >Notify Service in the Twilio Console</a
-              >. You should have already created one to deploy this project but
-              if not, you can create one now. Save the Notify Service SID in the
-              .env file.
-            </li>
-            <li>
-              In the Notify Service configuration tab, select your Messaging
-              Service under the "Messaging Service SID" drop down and save.
+              Open the <a href="/broadcast.html" target="_blank">broadcast page</a>, enter the passcode you defined during set up and the message you want to send and press "Send message".
             </li>
           </ol>
         </section>


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

This PR fixes two issues found when deploying the template using Quick Deploy:
1. Current Quick Deploy will set empty optional variables as `""`. While this should be fixed in the system, this works as a workaround in the meantime.
2. For some reason in the deployed Twilio Functions the `service.phoneNumbers.list` call was throwing an error so I changed it to a more explicit call.

This PR also adjusts the usage steps since they are no longer relevant.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
