### PR TITLE
Adds lookup template with carrier and caller name selection

### DIFF
--- a/lookup/README.md
+++ b/lookup/README.md
@@ -1,0 +1,75 @@
+# Phone number lookup
+
+This project will show you how to look up a phone number to get different types of information including:
+
+1. Validation and Formatting. Detects invalid phone numbers and parses numbers into the [standardized E.164 format]((https://www.twilio.com/docs/glossary/what-e164))
+2. Carrier. Detects line type (i.e. mobile, landline, voip) and carrier.
+3. Caller name. Subscriber info, US only.
+
+More details in the [Lookup API documentation](https://www.twilio.com/docs/lookup/api).
+
+For a production use case we recommend adding [phone verification](https://github.com/twilio-labs/function-templates/tree/main/verify), which is a best practice for collecting phone numbers from your users in order to make sure they have control of the number.
+
+## How to use the template
+
+The best way to use the Function templates is through the Twilio CLI as described below. If you'd like to use the template without the Twilio CLI, [check out our usage docs](../docs/USING_FUNCTIONS.md).
+
+### Environment variables
+
+This project requires some environment variables to be set. To keep your tokens and secrets secure, make sure to not commit the `.env` file in git. When setting up the project with `twilio serverless:init ...` the Twilio CLI will create a `.gitignore` file that excludes `.env` from the version history.
+
+In your `.env` file, set the following values:
+
+| Variable             | Meaning                                                           | Required |
+| :------------------- | :---------------------------------------------------------------- | :------- |
+| `ACCOUNT_SID`        | Find in the [console](https://www.twilio.com/console)             | Yes      |
+| `AUTH_TOKEN`         | Find in the [console](https://www.twilio.com/console)             | Yes      |
+
+### Function Parameters
+
+`lookup.js` expects the following parameters:
+
+| Parameter      | Description                                 | Required |
+| :------------- | :------------------------------------------ | :------- |
+| `phone`        | Phone number in [E.164 format](https://www.twilio.com/docs/glossary/what-e164) | Yes |
+| `types`        | Optional. Can provide 'carrier' and 'caller-name' for additional details, defaults to formatting lookup. | No |
+
+
+## Create a new project with the template
+
+1. Install the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart#install-twilio-cli)
+2. Install the [serverless toolkit](https://www.twilio.com/docs/labs/serverless-toolkit/getting-started)
+
+```shell
+twilio plugins:install @twilio-labs/plugin-serverless
+```
+
+3. Initiate a new project
+
+```
+twilio serverless:init lookup-sample --template=lookup && cd lookup-sample
+```
+
+4. Add your environment variables to `.env`:
+
+Make sure variables are populated in your `.env` file. See [Environment variables](#environment-variables).
+
+5. Start the server :
+
+```
+npm start
+```
+
+5. Open the web page at https://localhost:3000/index.html and enter your phone number to test
+
+ℹ️ Check the developer console and terminal for any errors, make sure you've set your environment variables.
+
+## Deploying
+
+Deploy your functions and assets with either of the following commands. Note: you must run these commands from inside your project folder. [More details in the docs.](https://www.twilio.com/docs/labs/serverless-toolkit)
+
+With the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart):
+
+```
+twilio serverless:deploy
+```

--- a/lookup/assets/index.html
+++ b/lookup/assets/index.html
@@ -27,7 +27,17 @@
         </a>
         library and detect invalid phone numbers, carrier information, and
         caller name with the
-        <a href="https://twilio.com/docs/lookup/api">Twilio Lookup API</a>.
+        <a href="https://twilio.com/docs/lookup/api">Twilio Lookup API</a>. New
+        data coming soon in V2.
+        <a href="https://www.twilio.com/docs/lookup/v2-api">
+          Learn more and sign up for early access.
+        </a>
+      </p>
+      <p>
+        New data coming soon in V2.
+        <a href="https://www.twilio.com/docs/lookup/v2-api">
+          Learn more and sign up for early access.
+        </a>
       </p>
       <div>
         <form id="lookup">
@@ -35,15 +45,8 @@
           <input id="phone" type="tel" name="phone" />
           <p>Request type:</p>
           <div>
-            <input
-              type="checkbox"
-              id="formatting"
-              name="types"
-              value="formatting"
-              checked
-              disabled
-            />
-            <label for="formatting">Formatting [free]</label><br />
+            <input type="checkbox" checked disabled />
+            <label>Formatting [free]</label><br />
           </div>
           <div>
             <input type="checkbox" id="carrier" name="types" value="carrier" />

--- a/lookup/assets/index.html
+++ b/lookup/assets/index.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Phone number lookup</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/intl-tel-input@17.0.13/build/css/intlTelInput.min.css"
+      integrity="sha256-xpVuhxDPR39wFEQDha4W7kuMx+z9Av3dTS8MbH/RWEU="
+      crossorigin="anonymous"
+    />
+    <script
+      src="https://cdn.jsdelivr.net/npm/intl-tel-input@17.0.13/build/js/intlTelInput.min.js"
+      integrity="sha256-uPbemOnf3P4eaeLHebLwPC71YRbu3WNBvO4ibYeBnGs="
+      crossorigin="anonymous"
+    ></script>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Phone number lookup</h1>
+      <p>
+        This example shows how to process and parse international phone numbers
+        with the
+        <a href="https://github.com/jackocnr/intl-tel-input">
+          <code>intl-tel-input</code>
+        </a>
+        library and detect invalid phone numbers, carrier information, and
+        caller name with the
+        <a href="https://twilio.com/docs/lookup/api">Twilio Lookup API</a>.
+      </p>
+      <div>
+        <form id="lookup">
+          <p>Enter your phone number:</p>
+          <input id="phone" type="tel" name="phone" />
+          <p>Request type:</p>
+          <div>
+            <input
+              type="checkbox"
+              id="formatting"
+              name="types"
+              value="formatting"
+              checked
+              disabled
+            />
+            <label for="formatting">Formatting [free]</label><br />
+          </div>
+          <div>
+            <input type="checkbox" id="carrier" name="types" value="carrier" />
+            <label for="carrier">Carrier [$0.005 / request]</label><br />
+          </div>
+          <div>
+            <input
+              type="checkbox"
+              id="caller-name"
+              name="types"
+              value="caller-name"
+            />
+            <label for="caller-name">
+              Caller name [USA Only; $0.01 / request]
+            </label>
+            <br />
+          </div>
+          <input type="submit" class="btn" value="Lookup" />
+        </form>
+        <div class="alert alert-info" style="display: none"></div>
+        <div class="alert alert-error" style="display: none"></div>
+      </div>
+    </div>
+    <script>
+      // Handle international prefixes, format phone input field
+      // Uses intl-tel-input plugin
+      const phoneInputField = document.querySelector('#phone');
+      const phoneInput = window.intlTelInput(phoneInputField, {
+        // https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+        preferredCountries: ['us', 'co', 'in', 'de'],
+        utilsScript:
+          'https://cdn.jsdelivr.net/npm/intl-tel-input@17.0.13/build/js/utils.js',
+      });
+
+      const info = document.querySelector('.alert-info');
+      const error = document.querySelector('.alert-error');
+
+      async function lookup(event) {
+        event.preventDefault();
+
+        try {
+          const phoneNumber = phoneInput.getNumber();
+
+          info.style.display = 'none';
+          error.style.display = 'none';
+
+          const data = {
+            phone: phoneNumber,
+            types: Array.from(
+              document.querySelectorAll('input[name=types]:checked')
+            ).map((t) => t.value),
+          };
+
+          const response = await fetch('./lookup', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data),
+          });
+
+          const json = await response.json();
+          if (response.status === 200) {
+            info.style.display = '';
+            info.innerHTML = `<pre>${JSON.stringify(json, null, 2)}</pre>`;
+          } else {
+            console.error(json.error);
+            error.style.display = '';
+            error.innerHTML = `Invalid phone number.`;
+          }
+        } catch (err) {
+          error.style.display = '';
+          error.innerHTML = `Something went wrong: ${err}`;
+        }
+      }
+
+      const form = document.getElementById('lookup');
+      form.addEventListener('submit', (event) => lookup(event));
+    </script>
+  </body>
+</html>

--- a/lookup/assets/styles.css
+++ b/lookup/assets/styles.css
@@ -1,0 +1,64 @@
+body {
+  font-family: Helvetica, sans-serif;
+}
+
+.container {
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 10px;
+}
+
+#phone,
+.btn {
+  padding-top: 6px;
+  padding-bottom: 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.btn {
+  color: #ffffff;
+  background-color: #428bca;
+  border-color: #357ebd;
+  font-size: 14px;
+  outline: none;
+  cursor: pointer;
+  margin-top: 20px;
+  padding-left: 12px;
+  padding-right: 12px;
+}
+
+.btn:focus,
+.btn:hover {
+  background-color: #3276b1;
+  border-color: #285e8e;
+}
+
+.btn:active {
+  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+}
+
+.alert {
+  padding: 15px;
+  margin-top: 10px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+}
+
+.alert-info {
+  border-color: #bce8f1;
+  color: #31708f;
+  background-color: #d9edf7;
+}
+
+.alert-error {
+  color: #a94442;
+  background-color: #f2dede;
+  border-color: #ebccd1;
+}
+
+.data {
+  background-color: lightgrey;
+  border-color: darkgray;
+}

--- a/lookup/changelog.md
+++ b/lookup/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/lookup/functions/lookup.js
+++ b/lookup/functions/lookup.js
@@ -1,0 +1,42 @@
+/**
+ *  Lookup - validate a phone number
+ *
+ *  This function will tell you whether or not a phone number is valid using Twilio's Lookup API
+ *
+ *  Parameters:
+ *  "phone" - string - phone number in E.164 format (https://www.twilio.com/docs/glossary/what-e164)
+ */
+
+// eslint-disable-next-line consistent-return
+exports.handler = async function (context, event, callback) {
+  const response = new Twilio.Response();
+  response.appendHeader('Content-Type', 'application/json');
+
+  /*
+   * uncomment to support CORS
+   * response.appendHeader('Access-Control-Allow-Origin', '*');
+   * response.appendHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+   * response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
+   */
+
+  try {
+    if (event.phone === '' || typeof event.phone === 'undefined') {
+      throw new Error('Missing parameter; please provide a phone number.');
+    }
+
+    const types = typeof event.types === 'object' ? event.types : [event.types];
+    const client = context.getTwilioClient();
+    const pn = await client.lookups
+      .phoneNumbers(event.phone)
+      .fetch({ type: types });
+
+    response.setStatusCode(200);
+    response.setBody(pn);
+    return callback(null, response);
+  } catch (error) {
+    console.error(error.message);
+    response.setStatusCode(error.status || 400);
+    response.setBody({ error: error.message });
+    return callback(null, response);
+  }
+};

--- a/lookup/package.json
+++ b/lookup/package.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "twilio": "^3.61.0"
+  }
+}

--- a/lookup/tests/lookup.test.js
+++ b/lookup/tests/lookup.test.js
@@ -1,0 +1,82 @@
+const lookupFunction = require('../functions/lookup').handler;
+const helpers = require('../../test/test-helper');
+
+const mockFetch = {
+  fetch: jest.fn(() => Promise.resolve({ sid: 'sid' })),
+};
+
+const mockClient = {
+  lookups: {
+    phoneNumbers: jest.fn(() => mockFetch),
+  },
+};
+
+const testContext = {
+  getTwilioClient: () => mockClient,
+};
+
+describe('international-telephone-input/lookup', () => {
+  beforeAll(() => {
+    helpers.setup({});
+  });
+  afterAll(() => {
+    helpers.teardown();
+  });
+
+  test('returns an error response when required parameter is missing', (done) => {
+    const callback = (_err, result) => {
+      expect(result).toBeDefined();
+      expect(result._statusCode).toEqual(400);
+      done();
+    };
+    const event = {};
+    lookupFunction(testContext, event, callback);
+  });
+
+  test('returns an error response when required parameter is empty', (done) => {
+    const callback = (_err, result) => {
+      expect(result).toBeDefined();
+      expect(result._statusCode).toEqual(400);
+      done();
+    };
+    const event = {
+      phone: '',
+    };
+    lookupFunction(testContext, event, callback);
+  });
+
+  test('formats types into a list if only given one', (done) => {
+    const event = {
+      phone: '+17341234567',
+      types: 'carrier',
+    };
+    const expectedParams = {
+      type: ['carrier'],
+    };
+    const callback = (_err, result) => {
+      expect(result).toBeDefined();
+      expect(result._statusCode).toEqual(200);
+      expect(mockFetch.fetch).toHaveBeenCalledWith(expectedParams);
+      done();
+    };
+    lookupFunction(testContext, event, callback);
+  });
+
+  test('returns success with valid request', (done) => {
+    const event = {
+      phone: '+17341234567',
+      types: ['formatting', 'carrier'],
+    };
+    const expectedParams = {
+      type: ['formatting', 'carrier'],
+    };
+    const callback = (_err, result) => {
+      expect(result).toBeDefined();
+      expect(result._statusCode).toEqual(200);
+      expect(mockFetch.fetch).toHaveBeenCalledWith(expectedParams);
+      expect(mockClient.lookups.phoneNumbers).toHaveBeenCalledWith(event.phone);
+      done();
+    };
+    lookupFunction(testContext, event, callback);
+  });
+});


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

We don't currently have a QD template that highlights the Lookup API, this fills that gap. [Live demo](https://lookup-8736-dev.twil.io/index.html)

Very similar to the international telephone input QD project but has explicit support for carrier and caller name lookup. 

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
