### PR TITLE
chore(verified-broadcast): bump runtime-handler version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9625,9 +9625,9 @@
       }
     },
     "@twilio-labs/serverless-runtime-types": {
-      "version": "2.2.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@twilio-labs/serverless-runtime-types/-/serverless-runtime-types-2.2.0-rc.0.tgz",
-      "integrity": "sha512-3GAv9LJxoGn+xQ3MFoEd8bIPg0GBj/Uby/sykfcYktVWrTZneBHV8S3y4RwNLKUWRD5oowO3xa5hmkR0uHYdPg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@twilio-labs/serverless-runtime-types/-/serverless-runtime-types-2.2.0.tgz",
+      "integrity": "sha512-rG5MPcaL+jplN4bT6Om3mcPc47/Y09nG9AG8eHI7qE6MPNo94N5AlV6PvDRRJ6YL4hvsgaas6SDVHoW0mW0t8w==",
       "dev": true,
       "requires": {
         "@types/express": "^4.17.11",
@@ -9650,12 +9650,12 @@
       }
     },
     "@twilio/runtime-handler": {
-      "version": "1.2.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@twilio/runtime-handler/-/runtime-handler-1.2.0-rc.3.tgz",
-      "integrity": "sha512-ZYOzeoe1UoI8MNPWtYFStF6Zm2l84nVMn26w0S0Dw6mYISeWAfm3U6WyPk4wcTeGJTW3r/rRdmBELJuVL8DOeQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@twilio/runtime-handler/-/runtime-handler-1.2.0.tgz",
+      "integrity": "sha512-M1SaPh2ZBQ3X+efXwwZwbeCVjz206sZ1aRlWV2deSsiK2IfYM8cVQv36uljIurpUvyVIO2lW0Na8BR/hVjmp5Q==",
       "dev": true,
       "requires": {
-        "@twilio-labs/serverless-runtime-types": "2.2.0-rc.0",
+        "@twilio-labs/serverless-runtime-types": "^2.2.0",
         "@types/express": "4.17.7",
         "chalk": "^4.1.1",
         "common-tags": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@google-cloud/dialogflow": "^4.1.0",
     "@twilio-labs/serverless-api": "^1.1.0",
-    "@twilio/runtime-handler": "1.2.0-rc.3",
+    "@twilio/runtime-handler": "1.2.0",
     "airtable": "^0.11.0",
     "aws-sdk": "^2.925.0",
     "basic-auth": "^2.0.1",

--- a/verified-broadcast/package.json
+++ b/verified-broadcast/package.json
@@ -2,7 +2,7 @@
   "version": "1.1.0",
   "private": true,
   "dependencies": {
-    "@twilio/runtime-handler": "1.2.0-rc.3",
+    "@twilio/runtime-handler": "1.2.0",
     "basic-auth": "^2.0.1",
     "tsscmp": "^1.0.6",
     "twilio": "^3.67.2"


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

Version 1.2.0 of runtime-handler is no more in preview so bumping this to get rid of the RC version.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
