### PR TITLE
fix error 60306 due to request information such as headers being passed as Details field value

### DIFF
--- a/verify-push-backend/functions/create-challenge.js
+++ b/verify-push-backend/functions/create-challenge.js
@@ -67,7 +67,7 @@ exports.handler = function (context, event, callback) {
   const serviceSid = context.VERIFY_SERVICE_SID;
   const hashIdentity = context.IDENTITY_PROCESSING !== 'raw';
 
-  const { identity, message, factor, hiddenDetails, ...details } = event;
+  const { identity, message, factor, hiddenDetails, request, ...details } = event;
   const identityValue = hashIdentity ? digestMessage(identity) : identity;
 
   const fields = [];


### PR DESCRIPTION

<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description
The `create-challenge` function breaks when deploying the code directly to a Twilio account. 

### Problem
The cause is that in the function code the `event` object is destructured in order to create the `details` object with every other field of `event` except the named ones on the destructuring, however the `request` field is not mentioned so it is treated as though as a details field which breaks the application getting the error message `Invalid request: Details.Fields[0] is too long, maximum length should be 196` 
<!-- a short description of your pull request -->

### Solution
I named the `request` field on said object destructuring to avoid the error but that are no guarantee that it won't happen again if a new field is added to `event` in the future.
Since it's a demo project I don't think it is a bid deal but maybe this endpoint should be a POST request getting the fields from the body, however any update of that nature would have to be reflected on the mobile demo projects as well in order for it to work.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->
