### PR TITLE
(feat: templates): add Caller ID + Call Forwarding

### DIFF
--- a/caller-id-forwarding/.env
+++ b/caller-id-forwarding/.env
@@ -1,0 +1,11 @@
+# Variables for function ""
+# ---
+# description: Calls made to your Twilio number will get forwarded to this e164-formatted phone number
+# format: phone_number
+# required: true
+# link: https://www.twilio.com/docs/glossary/what-e164
+MY_PHONE_NUMBER=+12223334444
+
+# description: The path to the webhook
+# configurable: false
+TWILIO_VOICE_WEBHOOK_URL=/forward-call

--- a/caller-id-forwarding/.owners
+++ b/caller-id-forwarding/.owners
@@ -1,0 +1,3 @@
+jmulcahey-twilio
+anishshandilya
+# Insert your Github username here

--- a/caller-id-forwarding/.owners
+++ b/caller-id-forwarding/.owners
@@ -1,3 +1,2 @@
-jmulcahey-twilio
 anishshandilya
 # Insert your Github username here

--- a/caller-id-forwarding/README.md
+++ b/caller-id-forwarding/README.md
@@ -2,7 +2,7 @@
 
 This Function in `forward-call.js` will complete 3 steps:
 
-1. Look up the incoming call number using the [Twilio Lookup API]()
+1. Look up the incoming call number using the [Twilio Lookup API](https://www.twilio.com/docs/lookup/api)
 1. Send an SMS to the forwarding number with Caller ID information
 1. Forward the incoming call to a number that is set in the environment variables.
 
@@ -18,4 +18,43 @@ This Function expects one environment variable to be set.
 
 ### Parameters
 
-This Function expects the incoming request to be a messaging webhook. The parameters that will be used are `From` and `Body`.
+This Function expects the incoming request to be a [voice webhook](https://www.twilio.com/docs/voice/api/call-resource?code-sample=code-fetch-a-call-resource&code-language=Node.js&code-sdk-version=3.x). The parameter used is `From`.
+
+## Create a new project with the template
+
+1. Install the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart#install-twilio-cli)
+2. Install the [serverless toolkit](https://www.twilio.com/docs/labs/serverless-toolkit/getting-started)
+
+```shell
+twilio plugins:install @twilio-labs/plugin-serverless
+```
+
+3. Initiate a new project
+
+```
+twilio serverless:init caller-id-forwarding --template=caller-id-forwarding
+cd caller-id-forwarding
+```
+
+4. Add your environment variables to `.env`:
+
+Make sure variables are populated in your `.env` file. See [Environment variables](#environment-variables).
+
+5. Deploy
+
+Deploy your functions and assets with the following commands. Note: you must run the command from inside your project folder. [More details in the docs.](https://www.twilio.com/docs/labs/serverless-toolkit)
+
+With the [Twilio CLI](https://www.twilio.com/docs/twilio-cli/quickstart):
+
+```
+twilio serverless:deploy
+```
+
+6. Connect your Twilio phone number to your callback URL:
+
+Replace the phone number with your Twilio Number and the `voice-url` with your deployed URL. You can also do this in the console settings page for the phone number.
+
+```
+twilio api:core:phone-numbers:update +11111111111 --voice-url https://YOUR_URL_HERE/twil.io/forward-call
+```
+

--- a/caller-id-forwarding/README.md
+++ b/caller-id-forwarding/README.md
@@ -1,0 +1,21 @@
+# Caller ID with Call Forwarding
+
+This Function in `forward-call.js` will complete 3 steps:
+
+1. Look up the incoming call number using the [Twilio Lookup API]()
+1. Send an SMS to the forwarding number with Caller ID information
+1. Forward the incoming call to a number that is set in the environment variables.
+
+**Note: `caller-name` lookup is currently only available in the US.**
+
+### Environment variables
+
+This Function expects one environment variable to be set.
+
+| Variable          | Meaning                                                                                                                                                              |
+| :---------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MY_PHONE_NUMBER` | The number you want to forward incoming messages to [in E.164 format](https://support.twilio.com/hc/en-us/articles/223183008-Formatting-International-Phone-Numbers) |
+
+### Parameters
+
+This Function expects the incoming request to be a messaging webhook. The parameters that will be used are `From` and `Body`.

--- a/caller-id-forwarding/assets/index.html
+++ b/caller-id-forwarding/assets/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <title>Get started with your Twilio Functions!</title>
+
+    <link
+      rel="icon"
+      href="https://twilio-labs.github.io/function-templates/static/v1/favicon.ico"
+    />
+    <link
+      rel="stylesheet"
+      href="https://twilio-labs.github.io/function-templates/static/v1/ce-paste-theme.css"
+    />
+    <script
+      src="https://twilio-labs.github.io/function-templates/static/v1/ce-helpers.js"
+      defer
+    ></script>
+    <script>
+      window.addEventListener('DOMContentLoaded', (_event) => {
+        inputPrependBaseURL();
+      });
+    </script>
+  </head>
+  <body>
+    <div class="page-top">
+      <header>
+        <div id="twilio-logo">
+          <a href="https://www.twilio.com/" target="_blank" rel="noopener">
+            <svg
+              class="logo"
+              data-name="Layer 1"
+              xmlns="http://www.w3.org/2000/svg"
+              viewbox="0 0 60 60"
+            >
+              <title>Twilio Logo</title>
+              <path
+                class="cls-1"
+                d="M30,15A15,15,0,1,0,45,30,15,15,0,0,0,30,15Zm0,26A11,11,0,1,1,41,30,11,11,0,0,1,30,41Zm6.8-14.7a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,26.3Zm0,7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,36.8,33.7Zm-7.4,0a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,33.7Zm0-7.4a3.1,3.1,0,1,1-3.1-3.1A3.12,3.12,0,0,1,29.4,26.3Z"
+              />
+            </svg>
+          </a>
+        </div>
+        <nav>
+          <span>Your Twilio application</span>
+          <aside>
+            <svg
+              class="icon"
+              role="img"
+              aria-hidden="true"
+              width="100%"
+              height="100%"
+              viewBox="0 0 20 20"
+              aria-labelledby="NewIcon-1577"
+            >
+              <path
+                fill="currentColor"
+                fill-rule="evenodd"
+                d="M6.991 7.507c.003-.679 1.021-.675 1.019.004-.012 2.956 1.388 4.41 4.492 4.48.673.016.66 1.021-.013 1.019-2.898-.011-4.327 1.446-4.48 4.506-.033.658-1.01.639-1.018-.02-.03-3.027-1.382-4.49-4.481-4.486-.675 0-.682-1.009-.008-1.019 3.02-.042 4.478-1.452 4.49-4.484zm.505 2.757l-.115.242c-.459.9-1.166 1.558-2.115 1.976l.176.08c.973.465 1.664 1.211 2.083 2.22l.02.05.088-.192c.464-.973 1.173-1.685 2.123-2.124l.039-.018-.118-.05c-.963-.435-1.667-1.117-2.113-2.034l-.068-.15zm10.357-8.12c.174.17.194.434.058.625l-.058.068-1.954 1.905 1.954 1.908a.482.482 0 010 .694.512.512 0 01-.641.056l-.07-.056-1.954-1.908-1.954 1.908a.511.511 0 01-.71 0 .482.482 0 01-.058-.626l.058-.068 1.954-1.908-1.954-1.905a.482.482 0 010-.693.512.512 0 01.64-.057l.07.057 1.954 1.905 1.954-1.905a.511.511 0 01.71 0z"
+              ></path>
+            </svg>
+            Live
+          </aside>
+        </nav>
+      </header>
+    </div>
+    <main>
+      <div class="content">
+        <h1>
+          <img
+            src="https://twilio-labs.github.io/function-templates/static/v1/success.svg"
+          />
+          <div>
+            <p>Welcome!</p>
+            <p>Your live application with Twilio is ready to use!</p>
+          </div>
+        </h1>
+        <section>
+          <h2>Get started with your application</h2>
+          <p>Follow these steps to try out your new app:</p>
+          <p>
+            This app will send an SMS with Caller ID information and return the
+            <a
+              href="https://www.twilio.com/docs/sms/twiml"
+              target="_blank"
+              rel="noopener"
+              >TwiML</a
+            >
+            required to forward an incoming call to a number that is set in the
+            environment variables.
+          </p>
+          <ol class="steps">
+            <li>Call your Twilio phone number</li>
+            <li>
+              Twilio will
+              <a href="https://www.twilio.com/docs/lookup/api">look up</a> the
+              phone number
+            </li>
+            <li>Receive an SMS with Caller ID information</li>
+            <li>
+              Receive the forwarded call at the number you configured the app to
+              use
+            </li>
+          </ol>
+        </section>
+        <section>
+          <!-- APP_INFO_V2 -->
+        </section>
+        <section>
+          <h2>Troubleshooting</h2>
+          <ul>
+            <li>
+              Check the
+              <a
+                href="https://www.twilio.com/console/phone-numbers/incoming"
+                target="_blank"
+                rel="noopener"
+              >
+                phone number configuration
+              </a>
+              and make sure the Twilio phone number you want for your app has a
+              voice webhook configured to point at the following URL
+              <form>
+                <label for="twilio-webhook">Webhook URL</label>
+                <input
+                  type="text"
+                  id="twilio-webhook"
+                  class="function-root"
+                  readonly="true"
+                  value="/forward-call"
+                />
+              </form>
+            </li>
+          </ul>
+        </section>
+      </div>
+    </main>
+    <footer>
+      <span class="statement">We can't wait to see what you build.</span>
+    </footer>
+  </body>
+</html>

--- a/caller-id-forwarding/changelog.md
+++ b/caller-id-forwarding/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0]
+### Added
+- Initial release.
+

--- a/caller-id-forwarding/functions/forward-call.protected.js
+++ b/caller-id-forwarding/functions/forward-call.protected.js
@@ -1,0 +1,24 @@
+exports.handler = async function (context, event, callback) {
+  const client = context.getTwilioClient();
+
+  const lookup = await client.lookups.v1
+    .phoneNumbers(event.From)
+    .fetch({ type: ['carrier', 'caller-name'] });
+
+  const callerName = lookup.callerName.caller_name;
+  const carrierName = lookup.carrier.name;
+
+  const body = `Incoming call from ${event.From}
+Name: ${callerName === null ? 'Unknown' : callerName}
+Carrier: ${carrierName} (${lookup.carrier.type})`;
+
+  await client.messages.create({
+    body,
+    from: context.TWILIO_PHONE_NUMBER,
+    to: context.MY_PHONE_NUMBER,
+  });
+
+  const twiml = new Twilio.twiml.VoiceResponse();
+  twiml.dial(context.MY_PHONE_NUMBER);
+  callback(null, twiml);
+};

--- a/caller-id-forwarding/functions/forward-call.protected.js
+++ b/caller-id-forwarding/functions/forward-call.protected.js
@@ -18,8 +18,6 @@ Carrier: ${carrierName} (${lookup.carrier.type})`;
       from: context.TWILIO_PHONE_NUMBER,
       to: context.MY_PHONE_NUMBER,
     });
-
-    return callback(null, twiml);
   } catch (error) {
     console.error(error);
   } finally {

--- a/caller-id-forwarding/functions/forward-call.protected.js
+++ b/caller-id-forwarding/functions/forward-call.protected.js
@@ -1,24 +1,31 @@
 exports.handler = async function (context, event, callback) {
-  const client = context.getTwilioClient();
+  try {
+    const client = context.getTwilioClient();
 
-  const lookup = await client.lookups.v1
-    .phoneNumbers(event.From)
-    .fetch({ type: ['carrier', 'caller-name'] });
+    const lookup = await client.lookups.v1
+      .phoneNumbers(event.From)
+      .fetch({ type: ['carrier', 'caller-name'] });
 
-  const callerName = lookup.callerName.caller_name;
-  const carrierName = lookup.carrier.name;
+    const callerName = lookup.callerName.caller_name;
+    const carrierName = lookup.carrier.name;
 
-  const body = `Incoming call from ${event.From}
+    const body = `Incoming call from ${event.From}
 Name: ${callerName === null ? 'Unknown' : callerName}
 Carrier: ${carrierName} (${lookup.carrier.type})`;
 
-  await client.messages.create({
-    body,
-    from: context.TWILIO_PHONE_NUMBER,
-    to: context.MY_PHONE_NUMBER,
-  });
+    await client.messages.create({
+      body,
+      from: context.TWILIO_PHONE_NUMBER,
+      to: context.MY_PHONE_NUMBER,
+    });
 
-  const twiml = new Twilio.twiml.VoiceResponse();
-  twiml.dial(context.MY_PHONE_NUMBER);
-  callback(null, twiml);
+    return callback(null, twiml);
+  } catch (error) {
+    console.error(error);
+  } finally {
+    // forward the call even if caller ID fails
+    const twiml = new Twilio.twiml.VoiceResponse();
+    twiml.dial(context.MY_PHONE_NUMBER);
+    return callback(null, twiml);
+  }
 };

--- a/caller-id-forwarding/package.json
+++ b/caller-id-forwarding/package.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "twilio": "^3.61.0"
+  }
+}

--- a/caller-id-forwarding/tests/forward-call.test.js
+++ b/caller-id-forwarding/tests/forward-call.test.js
@@ -1,18 +1,16 @@
 const helpers = require('../../test/test-helper');
 const forwardCall = require('../functions/forward-call.protected').handler;
 
-const mockFetch = jest.fn(() =>
-  Promise.resolve({
-    carrier: {
-      name: 'Verizon',
-      type: 'mobile',
-    },
-    callerName: {
-      // eslint-disable-next-line camelcase
-      caller_name: 'Lottie Matthews',
-    },
-  })
-);
+const mockFetch = jest.fn().mockResolvedValue({
+  carrier: {
+    name: 'Verizon',
+    type: 'mobile',
+  },
+  callerName: {
+    // eslint-disable-next-line camelcase
+    caller_name: 'Lottie Matthews',
+  },
+});
 
 const mockClient = {
   lookups: {
@@ -62,7 +60,7 @@ test('looks up the incoming phone number', (done) => {
   };
   const callback = (_err, result) => {
     expect(result).toBeDefined();
-    expect(mockClient.lookups.v1.phoneNumbers).toHaveBeenCalledWith('54321');
+    expect(mockClient.lookups.v1.phoneNumbers).toHaveBeenCalledWith(event.From);
     expect(mockFetch).toHaveBeenCalledWith(expectedParams);
     done();
   };
@@ -84,18 +82,16 @@ Carrier: Verizon (mobile)`,
     done();
   };
 
-  mockFetch.mockReturnValueOnce(
-    Promise.resolve({
-      callerName: {
-        // eslint-disable-next-line camelcase
-        caller_name: null,
-      },
-      carrier: {
-        name: 'Verizon',
-        type: 'mobile',
-      },
-    })
-  );
+  mockFetch.mockResolvedValueOnce({
+    callerName: {
+      // eslint-disable-next-line camelcase
+      caller_name: null,
+    },
+    carrier: {
+      name: 'Verizon',
+      type: 'mobile',
+    },
+  });
 
   forwardCall(context, event, callback);
 });

--- a/caller-id-forwarding/tests/forward-call.test.js
+++ b/caller-id-forwarding/tests/forward-call.test.js
@@ -1,0 +1,88 @@
+const helpers = require('../../test/test-helper');
+const forwardCall = require('../functions/forward-call.protected').handler;
+
+const mockFetch = {
+  fetch: jest.fn(() =>
+    Promise.resolve({
+      carrier: {
+        name: 'Verizon',
+        type: 'mobile',
+      },
+      callerName: {
+        // eslint-disable-next-line camelcase
+        caller_name: 'Lottie Matthews',
+      },
+    })
+  ),
+};
+
+const mockClient = {
+  lookups: {
+    v1: {
+      phoneNumbers: jest.fn(() => mockFetch),
+    },
+  },
+  messages: {
+    create: jest.fn(() => Promise.resolve({})),
+  },
+};
+
+const context = {
+  MY_PHONE_NUMBER: 'My Number',
+  TWILIO_PHONE_NUMBER: 'Twilio Number',
+  getTwilioClient: () => mockClient,
+};
+
+const event = {
+  From: '54321',
+};
+
+beforeAll(() => {
+  helpers.setup(context);
+});
+
+afterAll(() => {
+  helpers.teardown();
+});
+
+test('forwards the call to the number from the context', (done) => {
+  const callback = (_err, result) => {
+    expect(result.toString()).toMatch(
+      `<Dial>${context.MY_PHONE_NUMBER}</Dial>`
+    );
+    done();
+  };
+
+  forwardCall(context, event, callback);
+});
+
+test('looks up the incoming phone number', (done) => {
+  const expectedParams = {
+    type: ['carrier', 'caller-name'],
+  };
+  const callback = (_err, result) => {
+    expect(result).toBeDefined();
+    expect(mockClient.lookups.v1.phoneNumbers).toHaveBeenCalledWith('54321');
+    expect(mockFetch.fetch).toHaveBeenCalledWith(expectedParams);
+    done();
+  };
+
+  forwardCall(context, event, callback);
+});
+
+test('sends a message to the forwarding number', (done) => {
+  const callback = (_err, result) => {
+    expect(result).toBeDefined();
+    const expectedParams = {
+      body: `Incoming call from 54321
+Name: Lottie Matthews
+Carrier: Verizon (mobile)`,
+      to: context.MY_PHONE_NUMBER,
+      from: context.TWILIO_PHONE_NUMBER,
+    };
+    expect(mockClient.messages.create).toHaveBeenCalledWith(expectedParams);
+    done();
+  };
+
+  forwardCall(context, event, callback);
+});

--- a/caller-id-forwarding/tests/forward-call.test.js
+++ b/caller-id-forwarding/tests/forward-call.test.js
@@ -1,25 +1,25 @@
 const helpers = require('../../test/test-helper');
 const forwardCall = require('../functions/forward-call.protected').handler;
 
-const mockFetch = {
-  fetch: jest.fn(() =>
-    Promise.resolve({
-      carrier: {
-        name: 'Verizon',
-        type: 'mobile',
-      },
-      callerName: {
-        // eslint-disable-next-line camelcase
-        caller_name: 'Lottie Matthews',
-      },
-    })
-  ),
-};
+const mockFetch = jest.fn(() =>
+  Promise.resolve({
+    carrier: {
+      name: 'Verizon',
+      type: 'mobile',
+    },
+    callerName: {
+      // eslint-disable-next-line camelcase
+      caller_name: 'Lottie Matthews',
+    },
+  })
+);
 
 const mockClient = {
   lookups: {
     v1: {
-      phoneNumbers: jest.fn(() => mockFetch),
+      phoneNumbers: jest.fn(() => ({
+        fetch: mockFetch,
+      })),
     },
   },
   messages: {
@@ -63,9 +63,39 @@ test('looks up the incoming phone number', (done) => {
   const callback = (_err, result) => {
     expect(result).toBeDefined();
     expect(mockClient.lookups.v1.phoneNumbers).toHaveBeenCalledWith('54321');
-    expect(mockFetch.fetch).toHaveBeenCalledWith(expectedParams);
+    expect(mockFetch).toHaveBeenCalledWith(expectedParams);
     done();
   };
+
+  forwardCall(context, event, callback);
+});
+
+test('sets the callername to Unknown if not returned', (done) => {
+  const callback = (_err, result) => {
+    expect(result).toBeDefined();
+    const expectedParams = {
+      body: `Incoming call from 54321
+Name: Unknown
+Carrier: Verizon (mobile)`,
+      to: context.MY_PHONE_NUMBER,
+      from: context.TWILIO_PHONE_NUMBER,
+    };
+    expect(mockClient.messages.create).toHaveBeenCalledWith(expectedParams);
+    done();
+  };
+
+  mockFetch.mockReturnValueOnce(
+    Promise.resolve({
+      callerName: {
+        // eslint-disable-next-line camelcase
+        caller_name: null,
+      },
+      carrier: {
+        name: 'Verizon',
+        type: 'mobile',
+      },
+    })
+  );
 
   forwardCall(context, event, callback);
 });

--- a/templates.json
+++ b/templates.json
@@ -294,6 +294,11 @@
       "id": "contact-form",
       "name": "Email contact form",
       "description": "A contact form that uses SendGrid to send emails"
+    },
+    {
+      "id": "caller-id-forwarding",
+      "name": "Caller ID with call forwarding",
+      "description": "Set up a Twilio number to forward calls and receive an SMS with caller ID information when a call comes in."
     }
   ]
 }


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

Expansion of the call forwarding template. Before forwarding, looks up the incoming phone number and sends an SMS with caller id-like information to the forwarding number.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
