### PR TITLE
fix(contact-form): two small mistakes

### DIFF
--- a/contact-form/assets/index.html
+++ b/contact-form/assets/index.html
@@ -157,13 +157,14 @@
             console.log(data);
             setStatus(data.error, "error");
           }
-          sendButton.removeAttribute("disabled");
         } catch (error) {
           setStatus(
             "There was an error and the message could not be sent. Sorry.",
             "error"
           );
           console.log(error);
+        } finally {
+          sendButton.removeAttribute("disabled");
         }
       });
     </script>

--- a/contact-form/functions/send-email.js
+++ b/contact-form/functions/send-email.js
@@ -38,7 +38,6 @@ exports.handler = async function (context, event, callback) {
 
   try {
     await sg.send(msg);
-    const response = new Twilio.Response();
     response.setStatusCode(200);
     response.setBody({ success: true });
     return callback(null, response);


### PR DESCRIPTION
1. Front end: if a form submission fails due to a 500 error, the submit button previously stayed disabled. This adds a finally block to re-enable the button after everything else has happened.

2. Back end: two Twilio.Response objects were initialized when only one is needed.

## Checklist

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).
