### PR TITLE
fix(experimental-flex-dialpad): change env check for empty case

### DIFF
--- a/experimental-flex-dialpad/assets/helpers/setup.private.js
+++ b/experimental-flex-dialpad/assets/helpers/setup.private.js
@@ -7,7 +7,9 @@ const helpers = require('@twilio-labs/runtime-helpers');
 // const twilioClient = require('twilio')();
 
 function isNotEmptyString(variable) {
-  return typeof variable === 'string' && variable.length > 0;
+  return (
+    typeof variable === 'string' && variable.length > 0 && variable !== '""'
+  );
 }
 
 async function getWorkspaceSid(twilioClient) {


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->
Quick Deploy sets unconfigured empty variables to the value `""` which means it's technically not empty. This change adds that scenario to the check if a variable is empty.

## Description

<!-- a short description of your pull request -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
