### PR TITLE
Parameters passed to twiml.message were backwards. 

### DIFF
--- a/forward-message-multiple/functions/forward-message-multiple.protected.js
+++ b/forward-message-multiple/functions/forward-message-multiple.protected.js
@@ -1,9 +1,7 @@
 exports.handler = function (context, event, callback) {
   const twiml = new Twilio.twiml.MessagingResponse();
   context.FORWARDING_NUMBERS.split(/,\s?/).forEach((number) => {
-    twiml.message(`From: ${event.From}. Body: ${event.Body}`, {
-      to: number,
-    });
+    twiml.message({ to: number }, `From: ${event.From}. Body: ${event.Body}`);
   });
   callback(null, twiml);
 };

--- a/forward-message/functions/forward-message.protected.js
+++ b/forward-message/functions/forward-message.protected.js
@@ -1,7 +1,8 @@
 exports.handler = function (context, event, callback) {
   const twiml = new Twilio.twiml.MessagingResponse();
-  twiml.message(`From: ${event.From}. Body: ${event.Body}`, {
-    to: context.MY_PHONE_NUMBER,
-  });
+  twiml.message(
+    { to: context.MY_PHONE_NUMBER },
+    `From: ${event.From}. Body: ${event.Body}`
+  );
   callback(null, twiml);
 };


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

Parameters passed into `twiml.message` were backwards, causing the message being forwarded back to the sender and not to the number specified in the `to:` attibute. Placing the verb attributes before the message body fixed the issue. 

Using [docs](https://www.twilio.com/docs/messaging/twiml/message#messagestatus-reporting) as reference. 

<!-- a short description of your pull request -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
