### PR TITLE
fix(ai-assistants-samples): move to new API structure

### DIFF
--- a/ai-assistants-samples/assets/utils.private.js
+++ b/ai-assistants-samples/assets/utils.private.js
@@ -13,9 +13,8 @@ async function sendMessageToAssistant(context, assistantSid, body) {
     : context.TWILIO_REGION?.startsWith('dev')
       ? '.dev'
       : '';
-  const url = `https://assistants${environmentPrefix}.twilio.com/v1/${assistantSid}/Messages`;
+  const url = `https://assistants${environmentPrefix}.twilio.com/v1/Assistants/${assistantSid}/Messages`;
 
-  // Attention! There's explicitly no "await" since we want to do a "fire & forget"
   const response = await fetch(url, {
     method: 'POST',
     body: JSON.stringify(body),

--- a/ai-assistants-samples/functions/channels/conversations/flex-webchat.protected.js
+++ b/ai-assistants-samples/functions/channels/conversations/flex-webchat.protected.js
@@ -66,11 +66,12 @@ exports.handler = async function (context, event, callback) {
     params.append('_assistantIdentity', AssistantIdentity);
   }
   const body = {
-    Body,
-    Identity: identity,
-    SessionId: `conversations__${ChatServiceSid}/${ConversationSid}`,
+    body: Body,
+    identity,
+    // eslint-disable-next-line camelcase
+    session_id: `conversations__${ChatServiceSid}/${ConversationSid}`,
     // using a callback to handle AI Assistant responding
-    Webhook: `https://${
+    webhook: `https://${
       context.DOMAIN_NAME
     }/channels/conversations/response?${params.toString()}`,
   };

--- a/ai-assistants-samples/functions/channels/conversations/messageAdded.protected.js
+++ b/ai-assistants-samples/functions/channels/conversations/messageAdded.protected.js
@@ -52,11 +52,12 @@ exports.handler = async function (context, event, callback) {
     params.append('_assistantIdentity', AssistantIdentity);
   }
   const body = {
-    Body: event.Body,
-    Identity: identity,
-    SessionId: `conversations__${ChatServiceSid}/${ConversationSid}`,
+    body: event.Body,
+    identity,
+    // eslint-disable-next-line camelcase
+    session_id: `conversations__${ChatServiceSid}/${ConversationSid}`,
     // using a callback to handle AI Assistant responding
-    Webhook: `https://${
+    webhook: `https://${
       context.DOMAIN_NAME
     }/channels/conversations/response?${params.toString()}`,
   };

--- a/ai-assistants-samples/functions/channels/messaging/incoming.protected.js
+++ b/ai-assistants-samples/functions/channels/messaging/incoming.protected.js
@@ -20,12 +20,13 @@ exports.handler = async function (context, event, callback) {
 
   const token = await signRequest(context, event);
   const body = {
-    Body: event.Body,
-    Identity: event.From.startsWith('whatsapp:')
+    body: event.Body,
+    identity: event.From.startsWith('whatsapp:')
       ? event.From
       : `phone:${event.From}`,
-    SessionId: sessionId,
-    Webhook: `https://${context.DOMAIN_NAME}/channels/messaging/response?_token=${token}`,
+    // eslint-disable-next-line camelcase
+    session_id: sessionId,
+    webhook: `https://${context.DOMAIN_NAME}/channels/messaging/response?_token=${token}`,
   };
 
   const response = new Twilio.Response();


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

We are moving to a new API structure for AI Assistants. This is moving the sample code to the same one

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
