### PR TITLE
Add error handling for optional field when left empty

### DIFF
--- a/passkeys-backend/functions/registration/start.js
+++ b/passkeys-backend/functions/registration/start.js
@@ -22,6 +22,11 @@ exports.handler = async (context, event, callback) => {
 
   const { username, password } = context.getTwilioClient();
 
+  const androidOrigins = (keys) => {
+    if (!keys || keys.trim() === '""') return [];
+    return keys.split(',');
+  };
+
   // Request body sent to passkeys verify URL call
   /* eslint-disable camelcase */
   const requestBody = {
@@ -35,7 +40,7 @@ exports.handler = async (context, event, callback) => {
         name: 'PasskeySample',
         origins: [
           `https://${DOMAIN_NAME}`,
-          ...(ANDROID_APP_KEYS?.split(',') ?? []),
+          ...androidOrigins(ANDROID_APP_KEYS),
         ],
       },
       user: {

--- a/passkeys-backend/tests/registration-start.test.js
+++ b/passkeys-backend/tests/registration-start.test.js
@@ -107,6 +107,34 @@ describe('registration/start', () => {
     );
   });
 
+  // This is how the CodeExchange is populating the optional field if left empty
+  it('works with ANDROID_APP_KEYS empty string', (done) => {
+    const callback = (_, { _body }) => {
+      expect(axios.post).toHaveBeenCalledWith(
+        'https://api.com/Factors',
+        mockRequestBody,
+        { auth: { password: 'mockPassword', username: 'mockUsername' } }
+      );
+      done();
+    };
+
+    const mockContextWithoutAndroidKeys = {
+      API_URL: 'https://api.com',
+      ANDROID_APP_KEYS: '""',
+      DOMAIN_NAME: 'example.com',
+      getTwilioClient: () => ({
+        username: 'mockUsername',
+        password: 'mockPassword',
+      }),
+    };
+
+    handlerFunction(
+      mockContextWithoutAndroidKeys,
+      { username: 'user001' },
+      callback
+    );
+  });
+
   it('calls the API with the expected request body', (done) => {
     const modifiedRequest = structuredClone(mockRequestBody);
     modifiedRequest.content.relying_party.origins.push('key1', 'key2', 'key3');


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

Deploying from the [CodeExchange](https://www.twilio.com/code-exchange/verify-passkeys) leaves an "empty string" without stripping the quotes. This change handles that edge case.

<img width="501" alt="image" src="https://github.com/user-attachments/assets/36f7cc66-d0b1-412e-b973-6353f5ff314b" />


## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test passkeys-backend` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

<!-- List any related issues here -->
