### PR TITLE
Fix: Deprecated Action cache package version

### DIFF
--- a/.github/workflows/env-manifest.yml
+++ b/.github/workflows/env-manifest.yml
@@ -18,7 +18,7 @@ jobs:
       - name: install npm v8
         run: |
           npm install -g npm@8
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

Hopefully a quick fix for our failing Generate Env Manifest workflow. Please test before merge.

https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [ ] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->
