### PR TITLE
Fix video conference quick deploy

### DIFF
--- a/video/functions/video-token.js
+++ b/video/functions/video-token.js
@@ -32,7 +32,6 @@ exports.handler = function (context, event, callback) {
     { identity: ACCESS_TOKEN_IDENTITY }
   );
   accessToken.addGrant(videoGrant); // Add the grant to the token
-
   return callback(null, {
     token: accessToken.toJwt(), // Serialize the token to a JWT string
     room: ROOM_NAME,

--- a/video/functions/video-token.js
+++ b/video/functions/video-token.js
@@ -28,10 +28,11 @@ exports.handler = function (context, event, callback) {
   const accessToken = new AccessToken(
     TWILIO_ACCOUNT_SID,
     TWILIO_API_KEY,
-    TWILIO_API_SECRET
+    TWILIO_API_SECRET,
+    { identity: ACCESS_TOKEN_IDENTITY }
   );
   accessToken.addGrant(videoGrant); // Add the grant to the token
-  accessToken.identity = ACCESS_TOKEN_IDENTITY;
+
   return callback(null, {
     token: accessToken.toJwt(), // Serialize the token to a JWT string
     room: ROOM_NAME,


### PR DESCRIPTION

## Description

Access token error due to library changes in newer versions of twilio-node. The 'identity' is now required to be specified in options This replicates a fix for this issue on the ios quickstart - https://github.com/twilio/voice-quickstart-ios/issues/561



## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [ X] I ran `npm test` locally and it passed without errors.
- [ X] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

## Related issues

[See this issue here](https://github.com/twilio/voice-quickstart-ios/issues/561)
