### PR TITLE
fix(voice-ivr): correct env variable names to match deployment config

### DIFF
--- a/env-variables.manifest.json
+++ b/env-variables.manifest.json
@@ -904,13 +904,23 @@
     ],
     "voice-ivr": [
       {
-        "key": "MY_PHONE_NUMBER",
+        "key": "TWILIO_PHONE_NUMBER",
         "required": true,
         "format": "text",
         "description": "Your phone number for call forwarding (Sales option)\nEnter in E.164 format: https://www.twilio.com/docs/glossary/what-e164\nUse a test phone number during development",
         "link": null,
         "default": "+15551234567",
         "configurable": true,
+        "contentKey": null
+      },
+      {
+        "key": "TWILIO_VOICE_WEBHOOK_URL",
+        "required": true,
+        "format": "text",
+        "description": "The path to the webhook",
+        "link": null,
+        "default": "/voice-ivr",
+        "configurable": false,
         "contentKey": null
       }
     ],

--- a/voice-ivr/.env
+++ b/voice-ivr/.env
@@ -1,7 +1,7 @@
 # description: Your phone number
 # format: phone_number
 # required: true
-MY_PHONE_NUMBER=+12223334444
+TWILIO_PHONE_NUMBER=+12223334444
 
 # description: The path to the webhook
 # configurable: false

--- a/voice-ivr/.env.example
+++ b/voice-ivr/.env.example
@@ -1,9 +1,0 @@
-# Your phone number for call forwarding (Sales option)
-# Enter in E.164 format: https://www.twilio.com/docs/glossary/what-e164
-# Use a test phone number during development
-MY_PHONE_NUMBER=+15551234567
-
-# Note: The following Twilio credentials are automatically provided by Twilio Serverless
-# and do not need to be set in your .env file:
-# - ACCOUNT_SID: Your Twilio Account SID (https://www.twilio.com/console)
-# - AUTH_TOKEN: Your Twilio Auth Token (https://www.twilio.com/console)


### PR DESCRIPTION
<!-- Thank you for contributing to the Function Templates project. -->
<!-- Please fill out the template below for your contribution -->

## Description

Updated environment variable naming to fix deployment errors caused by
mismatched variable names. Changed `MY_PHONE_NUMBER` to `TWILIO_PHONE_NUMBER`
and added `TWILIO_VOICE_WEBHOOK_URL` to manifest to align with expected
deployment configuration.

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../blob/main/LICENSE).
